### PR TITLE
feat: automation with github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: build
+
+on:
+  pull_request:
+    branches:
+      - "3.7"
+      - "3.8"
+      - "3.9"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: sudo apt-get install gettext
+
+      - name: Build
+        run: VERSION=${{ github.event.pull_request.base.ref }} make

--- a/.github/workflows/deploy-gh-page.yml
+++ b/.github/workflows/deploy-gh-page.yml
@@ -1,0 +1,26 @@
+name: deploy-gh-page
+
+on:
+  push:
+    branches:
+      - "3.9"
+
+jobs:
+  cd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: sudo apt-get install gettext
+
+      - name: Build
+        run: make
+
+      - name: Deploy to gh page
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: ../cpython/Doc/build/html
+          CLEAN: true

--- a/.github/workflows/py39-sync-cpython.yml
+++ b/.github/workflows/py39-sync-cpython.yml
@@ -1,0 +1,52 @@
+name: python-3.9-sync-with-cpython
+
+on:
+  push:
+    branches:
+      - "3.9"
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: "3.9"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.VERSION }}
+
+      - name: Set env
+        run: echo "LATEST_COMMIT_ID=$(git ls-remote https://github.com/python/CPython.git $VERSION | head -c 8)" >> $GITHUB_ENV
+
+      - name: Install Dependencies
+        run: sudo apt-get install gettext
+
+      - name: Sync with CPython
+        run: make clone && make merge && make rm_cpython
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: sync with cpython ${{ env.LATEST_COMMIT_ID }}
+          committer: GitHub <noreply@github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          base: ${{ env.VERSION }}
+          branch: cron/sync/${{ env.VERSION }}
+          delete-branch: true
+          title: 'Sync with CPython ${{ env.VERSION }}'
+          body: |
+            Sync with CPython ${{ env.VERSION }}
+          labels: |
+            sync-cpython
+            automation
+          team-reviewers: |
+            owners
+            maintainers
+          
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,15 @@ JOBS = 1
 
 
 .PHONY: all
-all: $(VENV)/bin/sphinx-build $(VENV)/bin/blurb $(SPHINX_CONF)
+all: $(VENV)/bin/sphinx-build $(VENV)/bin/blurb clone
 	mkdir -p $(LC_MESSAGES)
 	for dirname in $$(find . -name '*.po' | xargs -n1 dirname | sort -u | grep -v '^\.$$'); do mkdir -p $(LC_MESSAGES)/$$dirname; done
 	for file in *.po */*.po; do ln -f $$file $(LC_MESSAGES)/$$file; done
 	. $(VENV)/bin/activate; $(MAKE) -C $(CPYTHON_CLONE)/Doc/ SPHINXOPTS='-j$(JOBS) -D locale_dirs=locales -D language=$(LANGUAGE) -D gettext_compact=0' $(MODE)
 
 
-$(SPHINX_CONF):
-	git clone --depth 1 --no-single-branch https://github.com/python/cpython.git $(CPYTHON_CLONE)
+clone:
+	git clone --depth 1 --no-single-branch https://github.com/python/cpython.git $(CPYTHON_CLONE)  || echo "cpython exists"
 	cd $(CPYTHON_CLONE) && git checkout $(BRANCH)
 
 
@@ -104,3 +104,7 @@ update_txconfig:
 .PHONY: fuzzy
 fuzzy:
 	for file in *.po */*.po; do echo $$(msgattrib --only-fuzzy --no-obsolete "$$file" | grep -c '#, fuzzy') $$file; done | grep -v ^0 | sort -gr
+
+.PHONY: rm_cpython
+rm_cpython:
+	rm -rf $(CPYTHON_CLONE)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LC_MESSAGES := $(CPYTHON_CLONE)/Doc/locales/$(LANGUAGE)/LC_MESSAGES
 VENV := ~/.venvs/python-docs-i18n/
 PYTHON := $(shell which python3)
 MODE := autobuild-dev-html
-BRANCH = $(shell git describe --contains --all HEAD)
+BRANCH := $(or $(VERSION), $(shell git describe --contains --all HEAD))
 JOBS = 1
 
 


### PR DESCRIPTION
## Purpose

This PR tend to automate several tasks with github action:

- Pulling latest source strings from [CPython](https://github.com/python/cpython) daily and make the change as a PR (only support branch `3.9`).
	- Maintainer should resolve the fuzzy entries before merging it.
	- If the PR for this task is existed, changes will be forced-push to the existing branch ([checkout `peter-evans/create-pull-request@v3`](https://github.com/marketplace/actions/create-pull-request#action-behaviour)).
- Launch build flow during a pull request is opened (supported base branch: `3.7`, `3.8`, & `3.9`).
- Deploy to github page if any change is pushed to main branch (current: `3.9`).

## Preview

These workflows are tested in my forked repo. One can check it out and learn how it works before merging this PR:

- Sync with CPython: 
  - [log of gh-action job](https://github.com/mattwang44/python-docs-zh-tw/runs/3516466334)
  - [auto-generated PR](https://github.com/mattwang44/python-docs-zh-tw/pull/7)
- Build:
  - [example of a failed build](https://github.com/mattwang44/python-docs-zh-tw/runs/3517078133) (I deliberately make a rst syntax error in [this PR](https://github.com/mattwang44/python-docs-zh-tw/pull/8)) 
  - [example of a success build](https://github.com/mattwang44/python-docs-zh-tw/runs/3516465894)
- Deploy to github page
  - [log of gh-action job](https://github.com/mattwang44/python-docs-zh-tw/runs/3516466312)
  - [resulting github page](https://mattwang44.github.io/python-docs-zh-tw)

## Caution

- Need @adrianliaw's help to setup github page (configure branch as `gh-pages` and folder as root).
![image](https://user-images.githubusercontent.com/24987826/132210532-7704b524-88c0-4f53-ba14-d4548901aaa6.png)
- To successfully deploy the site to github page, an empty file named `.nojekyll` is required to be committed to `gh-pages` branch after this PR is merged. It prevents github page from ignoring folders that start with underscores, which makes it failed to load css/js files (see [this reference](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/) and [this blog](https://www.docslikecode.com/articles/github-pages-python-sphinx/) for details).