### PR TITLE
fix(action): allow merging cpython on existing branch

### DIFF
--- a/.github/workflows/py39-sync-cpython.yml
+++ b/.github/workflows/py39-sync-cpython.yml
@@ -12,10 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: "3.9"
+      BRANCH: "cron/sync/3.9"
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.VERSION }}
+
+      - name: Get the changes on branch (if exists)
+        continue-on-error: true
+        run: |
+          git fetch origin ${{ env.BRANCH }}:${{ env.BRANCH }}
+          git reset --hard ${{ env.BRANCH }}
 
       - name: Set env
         run: echo "LATEST_COMMIT_ID=$(git ls-remote https://github.com/python/CPython.git $VERSION | head -c 8)" >> $GITHUB_ENV
@@ -41,8 +48,8 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           base: ${{ env.VERSION }}
-          branch: cron/sync/${{ env.VERSION }}
-          delete-branch: true
+          branch: ${{ env.BRANCH }}
+          delete-branch: false
           title: 'Sync with CPython ${{ env.VERSION }}'
           body: |
             Sync with CPython ${{ env.VERSION }}


### PR DESCRIPTION
## [WHY]

The procedure in current workflow for cpython-syncing is listed as follow:
1. Cronjob for syncing with cpython triggered daily. A draft PR is sent if any source string has changed.
2. Developers of this repo should check if the PR is good enough to be merged. Add commits to the same branch if needed (e.g. fixing fuzzy entry and updating translation based on modified source string). Convert it to regular PR if it's ready for review.
3. Reviewer review and merge this PR.

However, if any commit is added in the step 2. and the cpython-syncing job is triggered before step 3., the commit(s) will be eliminated when forced-pushing since the current workflow do not editing based on existing branch.

## [HOW]

Add a stage for reseting to existing branch. If the branch does not exist, this stage would fail but does not block the job.