### PR TITLE
doc: update issue link and amend translator list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,7 @@ type                  型別
 如果有需要共同討論的問題，請開設一個新的 Issue_。如果是翻譯上遇到困難需要\
 幫助，則可以使用 Telegram_。
 
-.. _Issue: https://github.com/python-doc-tw/python-docs-zh-tw/issues
+.. _Issue: https://github.com/python/python-docs-zh-tw/issues
 .. _Telegram: https://t.me/PyDocTW
 
 另外，此翻譯的 coordinator 為 `mattwang44 <https://github.com/mattwang44>`_ 和 \

--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -6,10 +6,36 @@ project, it may not be complete but you're always welcome to add your name
 here by making a pull request if you've contributed this project in any way.
 Kudos to any one who've contributed to this project!
 
-This list includes those who contributed on Transifex before May 2018, which
-is before the transition of the workflow from Transifex to GitHub. The names
-listed here are followed by the translator's Transifex user ID quoted using
-angle brackets, feel free to remove it if you prefer not to disclose it.
+Adrian Liaw (Wey-Han Liaw)
+Allen Wu (allen91wu)
+Benson Chen
+Grimmer
+Liang Bo Wang
+Patina Ho
+Scott Chang
+Sonia Wu
+Steven Hsu (StevenHsuYL)
+Taihsiang Ho (tai271828)
+Tsai, Chia-Wen
+Wei-Hsiang (Matt) Wang
+Wilson Wang (Josix)
+Yu Chun Yang
+Jason (chairco)
+chinghao.liu (chinghao-tw)
+jordanSu
+meowmeowcat
+nickbanana
+nienzu
+ttnppedr
+yichung
+zztin
+戴靖
+
+
+This list below includes those who contributed on Transifex before May 2018,
+which is before the transition of the workflow from Transifex to GitHub. The
+names listed here are followed by the translator's Transifex user ID quoted
+using angle brackets, feel free to remove it if you prefer not to disclose it.
 
 
 Liang-Bo Wang <ccwang002>


### PR DESCRIPTION
1. The link to the GitHub issue page is wrong (the old one is given).
2. Amend the translator list (the new list is derived from the git log command).