### PR TITLE
Fix a fuzzy in glossary.po

### DIFF
--- a/glossary.po
+++ b/glossary.po
@@ -1212,7 +1212,6 @@ msgstr ""
 "(parallelism)。"
 
 #: ../../glossary.rst:544
-#, fuzzy
 msgid ""
 "However, some extension modules, either standard or third-party, are "
 "designed so as to release the GIL when doing computationally intensive tasks "
@@ -1220,7 +1219,7 @@ msgid ""
 "I/O."
 msgstr ""
 "然而，有些擴充模組，無論是標準的或是第三方的，它們被設計成在執行壓縮或雜湊等"
-"計算密集 (computationally-intensive) 的任務時，可以解除 GIL。另外，在執行 I/"
+"計算密集 (computationally intensive) 的任務時，可以解除 GIL。另外，在執行 I/"
 "O 時，GIL 總是會被解除。"
 
 #: ../../glossary.rst:549


### PR DESCRIPTION
Resolve a fuzzy msgstr.

Preview:
![glossary-GIL](https://user-images.githubusercontent.com/81967953/180637434-c1b7316b-c988-4f1b-be3d-08cd2af88f54.jpeg)
