### PR TITLE
fix(Makefile): fallback sphinx version to <5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(VENV)/bin/activate:
 
 
 $(VENV)/bin/sphinx-build: $(VENV)/bin/activate
-	. $(VENV)/bin/activate; python3 -m pip install sphinx python-docs-theme
+	. $(VENV)/bin/activate; python3 -m pip install "sphinx<6" python-docs-theme
 
 
 $(VENV)/bin/blurb: $(VENV)/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(VENV)/bin/activate:
 
 
 $(VENV)/bin/sphinx-build: $(VENV)/bin/activate
-	. $(VENV)/bin/activate; python3 -m pip install "sphinx<6" python-docs-theme
+	. $(VENV)/bin/activate; python3 -m pip install "sphinx<5.3" python-docs-theme
 
 
 $(VENV)/bin/blurb: $(VENV)/bin/activate


### PR DESCRIPTION
The CI jobs failed after sphinx 5.3 was released. Limit the version <5.3 as a temporary solution.