### PR TITLE
Update glossary.po and tutorial/modules.po

### DIFF
--- a/glossary.po
+++ b/glossary.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Python 3.11\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-10-15 20:43+0000\n"
-"PO-Revision-Date: 2022-10-16 07:29+0800\n"
+"PO-Revision-Date: 2022-10-23 20:00+0800\n"
 "Last-Translator: Steven Hsu <hsuhaochun@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.2\n"
 
 #: ../../glossary.rst:5
 msgid "Glossary"
@@ -1631,7 +1631,7 @@ msgstr "在 Windows 上，它是 ANSI 代碼頁（code page，例如 ``\"cp1252\
 #: ../../glossary.rst:730
 msgid ""
 "On Android and VxWorks, Python uses ``\"utf-8\"`` as the locale encoding."
-msgstr ""
+msgstr "在 Android 和 VxWorks 上，Python 使用 ``\"utf-8\"`` 作為區域編碼。"
 
 #: ../../glossary.rst:732
 msgid "``locale.getencoding()`` can be used to get the locale encoding."

--- a/tutorial/modules.po
+++ b/tutorial/modules.po
@@ -5,14 +5,14 @@
 # Translators:
 # jerrychen <jerrychen.ee@gmail.com>, 2016
 # Adrian Liaw <adrianliaw2000@gmail.com>, 2018
-# Steven Hsu <hsuhaochun@gmail.com>, 2021
+# Steven Hsu <hsuhaochun@gmail.com>, 2021-2022
 # Phil Lin <linooohon@gmail.com>, 2022
 msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.11\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-10-15 20:43+0000\n"
-"PO-Revision-Date: 2022-07-07 00:38+0800\n"
+"PO-Revision-Date: 2022-10-23 20:30+0800\n"
 "Last-Translator: Phil Lin <linooohon@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.1\n"
+"X-Generator: Poedit 3.2\n"
 
 #: ../../tutorial/modules.rst:5
 msgid "Modules"
@@ -315,7 +315,7 @@ msgstr ""
 
 #: ../../tutorial/modules.rst:199
 msgid "More details are at :ref:`sys-path-init`."
-msgstr ""
+msgstr "在 :ref:`sys-path-init` 有更多的細節。"
 
 #: ../../tutorial/modules.rst:202
 msgid ""


### PR DESCRIPTION
Sync with cpython 3.11

Preview:
![glossary-locale](https://user-images.githubusercontent.com/81967953/197393616-3588268a-7020-4be1-80ac-8aa662447c32.jpeg)
![tutorial-modules](https://user-images.githubusercontent.com/81967953/197393623-a85ec980-a43d-4c11-bf67-669ad15c13bb.jpeg)
