### PR TITLE
Translate `library/concurrent.futures.po`

### DIFF
--- a/library/concurrent.futures.po
+++ b/library/concurrent.futures.po
@@ -1,15 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2001-2022, Python Software Foundation
+# Copyright (C) 2001-2023, Python Software Foundation
 # This file is distributed under the same license as the Python package.
 #
 # Translators:
+# Matt Wang <mattwang44@gmail.com>, 2023
 msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.11\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-13 00:17+0000\n"
-"PO-Revision-Date: 2018-05-23 14:41+0000\n"
-"Last-Translator: Adrian Liaw <adrianliaw2000@gmail.com>\n"
+"PO-Revision-Date: 2023-01-24 03:33+0800\n"
+"Last-Translator: Matt Wang <mattwang44@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
 "Language: zh_TW\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: ../../library/concurrent.futures.rst:2
 msgid ":mod:`concurrent.futures` --- Launching parallel tasks"
@@ -35,6 +36,8 @@ msgid ""
 "The :mod:`concurrent.futures` module provides a high-level interface for "
 "asynchronously executing callables."
 msgstr ""
+":mod:`concurrent.futures` 模組提供了一個高階介面來非同步地 (asynchronously) "
+"執行可呼叫物件 (callable) 。"
 
 #: ../../library/concurrent.futures.rst:17
 msgid ""
@@ -43,10 +46,13 @@ msgid ""
 "`ProcessPoolExecutor`.  Both implement the same interface, which is defined "
 "by the abstract :class:`Executor` class."
 msgstr ""
+"非同步執行可以透過 :class:`ThreadPoolExecutor` 來使用執行緒 (thread) 執行，或"
+"透過 :class:`ProcessPoolExecutor` 來使用單獨行程 (process) 執行。兩者都實作了"
+"相同的介面，該介面由抽象的 :class:`Executor` 類別定義。"
 
 #: ../../includes/wasm-notavail.rst:3
 msgid ":ref:`Availability <availability>`: not Emscripten, not WASI."
-msgstr ""
+msgstr ":ref:`適用 <availability>`：非 Emscripten、非 WASI。"
 
 #: ../../includes/wasm-notavail.rst:5
 msgid ""
@@ -54,16 +60,20 @@ msgid ""
 "``wasm32-emscripten`` and ``wasm32-wasi``. See :ref:`wasm-availability` for "
 "more information."
 msgstr ""
+"此模組在 WebAssembly 平台 ``wasm32-emscripten`` 和 ``wasm32-wasi`` 上沒有作用"
+"或不可使用。更多資訊，請參閱 :ref:`wasm-availability`。"
 
 #: ../../library/concurrent.futures.rst:25
 msgid "Executor Objects"
-msgstr ""
+msgstr "Executor 物件"
 
 #: ../../library/concurrent.futures.rst:29
 msgid ""
 "An abstract class that provides methods to execute calls asynchronously.  It "
 "should not be used directly, but through its concrete subclasses."
 msgstr ""
+"提供非同步執行呼叫方法的抽象類別。不應直接使用它，而應透過其具體子類別來使"
+"用。"
 
 #: ../../library/concurrent.futures.rst:34
 msgid ""
@@ -71,20 +81,24 @@ msgid ""
 "returns a :class:`Future` object representing the execution of the "
 "callable. ::"
 msgstr ""
+"為可呼叫物件 *fn* 排程來以 ``fn(*args, **kwargs)`` 的形式執行並回傳一個表示可"
+"呼叫的執行的 :class:`Future` 物件。\n"
+"\n"
+"::"
 
 #: ../../library/concurrent.futures.rst:44
 msgid "Similar to :func:`map(func, *iterables) <map>` except:"
-msgstr ""
+msgstr "類似於 :func:`map(func, *iterables) <map>`，除了："
 
 #: ../../library/concurrent.futures.rst:46
 msgid "the *iterables* are collected immediately rather than lazily;"
-msgstr ""
+msgstr "*iterables* 立即被收集而不是延遲 (lazily) 收集；"
 
 #: ../../library/concurrent.futures.rst:48
 msgid ""
 "*func* is executed asynchronously and several calls to *func* may be made "
 "concurrently."
-msgstr ""
+msgstr "*func* 是非同步執行的，並且對 *func* 的多次呼叫可以並行處理。"
 
 #: ../../library/concurrent.futures.rst:51
 msgid ""
@@ -94,12 +108,16 @@ msgid ""
 "float.  If *timeout* is not specified or ``None``, there is no limit to the "
 "wait time."
 msgstr ""
+"如果 :meth:`~iterator.__next__` 被呼叫，且在原先呼叫 :meth:`Executor.map` 的 "
+"*timeout* 秒後結果仍不可用，回傳的疊代器就會引發 :exc:`TimeoutError`。"
+"*timeout* 可以是整數或浮點數。如果未指定 *timeout* 或為 ``None``，則等待時間"
+"就不會有限制。"
 
 #: ../../library/concurrent.futures.rst:57
 msgid ""
 "If a *func* call raises an exception, then that exception will be raised "
 "when its value is retrieved from the iterator."
-msgstr ""
+msgstr "如果 *func* 呼叫引發例外，則當從疊代器中檢索到它的值時將引發該例外。"
 
 #: ../../library/concurrent.futures.rst:60
 msgid ""
@@ -110,6 +128,11 @@ msgid ""
 "*chunksize* can significantly improve performance compared to the default "
 "size of 1.  With :class:`ThreadPoolExecutor`, *chunksize* has no effect."
 msgstr ""
+"使用 :class:`ProcessPoolExecutor` 時，此方法將 *iterables* 分成許多分塊 "
+"(chunks)，並將其作為獨立的任務來提交給池 (pool)。可以透過將 *chunksize* 設定"
+"為正整數來指定這些分塊的（約略）大小。對於非常長的可疊代物件，*chunksize* 使"
+"用較大的值（與預設大小 1 相比）可以顯著提高性能。對於 :class:"
+"`ThreadPoolExecutor`，*chunksize* 無效。"
 
 #: ../../library/concurrent.futures.rst:68
 msgid "Added the *chunksize* argument."
@@ -122,6 +145,9 @@ msgid ""
 "submit` and :meth:`Executor.map` made after shutdown will raise :exc:"
 "`RuntimeError`."
 msgstr ""
+"向 executor 發出訊號 (signal)，表明它應該在當前未定 (pending) 的 future 完成"
+"執行時釋放它正在使用的任何資源。在關閉後呼叫 :meth:`Executor.submit` 和 :"
+"meth:`Executor.map` 將引發 :exc:`RuntimeError`。"
 
 #: ../../library/concurrent.futures.rst:78
 msgid ""
@@ -133,6 +159,11 @@ msgid ""
 "*wait*, the entire Python program will not exit until all pending futures "
 "are done executing."
 msgstr ""
+"如果 *wait* 為 ``True`` 則此方法將不會回傳，直到所有未定的 futures 完成執行並"
+"且與 executor 關聯的資源都被釋放。如果 *wait* 為 ``False`` 則此方法將立即回"
+"傳，並且當所有未定的 future 執行完畢時，與 executor 關聯的資源將被釋放。不管 "
+"*wait* 的值如何，整個 Python 程式都不會退出，直到所有未定的 futures 執行完"
+"畢。"
 
 #: ../../library/concurrent.futures.rst:86
 msgid ""
@@ -140,6 +171,9 @@ msgid ""
 "that the executor has not started running. Any futures that are completed or "
 "running won't be cancelled, regardless of the value of *cancel_futures*."
 msgstr ""
+"如果 *cancel_futures* 為 ``True``，此方法將取消 executor 尚未開始運行的所有未"
+"定 future。無論 *cancel_futures* 的值如何，任何已完成或正在運行的 future 都不"
+"會被取消。"
 
 #: ../../library/concurrent.futures.rst:91
 msgid ""
@@ -147,6 +181,8 @@ msgid ""
 "executor has started running will be completed prior to this method "
 "returning. The remaining futures are cancelled."
 msgstr ""
+"如果 *cancel_futures* 和 *wait* 都為 ``True``，則 executor 已開始運行的所有 "
+"future 將在此方法回傳之前完成。剩餘的 future 被取消。"
 
 #: ../../library/concurrent.futures.rst:95
 msgid ""
@@ -154,6 +190,11 @@ msgid ""
 "`with` statement, which will shutdown the :class:`Executor` (waiting as if :"
 "meth:`Executor.shutdown` were called with *wait* set to ``True``)::"
 msgstr ""
+"如果使用 :keyword:`with` 陳述句，你就可以不用明確地呼叫此方法，這將會自己關"
+"閉 :class:`Executor`\\（如同呼叫 :meth:`Executor.shutdown` 時 *wait* 被設定"
+"為 ``True`` 般等待）：\n"
+"\n"
+"::"
 
 #: ../../library/concurrent.futures.rst:107
 msgid "Added *cancel_futures*."
@@ -168,12 +209,18 @@ msgid ""
 ":class:`ThreadPoolExecutor` is an :class:`Executor` subclass that uses a "
 "pool of threads to execute calls asynchronously."
 msgstr ""
+":class:`ThreadPoolExecutor` 是一個 :class:`Executor` 子類別，它使用執行緒池來"
+"非同步地執行呼叫。"
 
 #: ../../library/concurrent.futures.rst:117
 msgid ""
 "Deadlocks can occur when the callable associated with a :class:`Future` "
 "waits on the results of another :class:`Future`.  For example::"
 msgstr ""
+"當與 :class:`Future` 關聯的可呼叫物件等待另一個 :class:`Future` 的結果時，可"
+"能會發生死鎖 (deadlock)。例如：\n"
+"\n"
+"::"
 
 #: ../../library/concurrent.futures.rst:136
 msgid "And::"
@@ -187,6 +234,8 @@ msgid ""
 "An :class:`Executor` subclass that uses a pool of at most *max_workers* "
 "threads to execute calls asynchronously."
 msgstr ""
+"一個 :class:`Executor` 子類別，它使用最多有 *max_workers* 個執行緒的池來非同"
+"步地執行呼叫。"
 
 #: ../../library/concurrent.futures.rst:153
 msgid ""
@@ -197,6 +246,11 @@ msgid ""
 "exit gracefully. For this reason, it is recommended that "
 "``ThreadPoolExecutor`` not be used for long-running tasks."
 msgstr ""
+"所有排隊到 ``ThreadPoolExecutor`` 的執行緒都將在直譯器退出之前加入。請注意，"
+"執行此操作的退出處理程式會在任何使用 ``atexit`` 新增的退出處理程式\\ *之前"
+"*\\ 執行。這意味著必須捕獲並處理主執行緒中的例外，以便向執行緒發出訊號來正常"
+"退出 (gracefully exit)。因此，建議不要將 ``ThreadPoolExecutor`` 用於長時間運"
+"行的任務。"
 
 #: ../../library/concurrent.futures.rst:160
 msgid ""
@@ -206,6 +260,10 @@ msgid ""
 "jobs will raise a :exc:`~concurrent.futures.thread.BrokenThreadPool`, as "
 "well as any attempt to submit more jobs to the pool."
 msgstr ""
+"*initializer* 是一個可選的可呼叫物件，在每個工作執行緒開始時呼叫； "
+"*initargs* 是傳遞給 initializer 的引數元組 (tuple)。如果 *initializer* 引發例"
+"外，所有當前未定的作業以及任何向池中提交 (submit) 更多作業的嘗試都將引發 :"
+"exc:`~concurrent.futures.thread.BrokenThreadPool`。"
 
 #: ../../library/concurrent.futures.rst:166
 msgid ""
@@ -215,6 +273,10 @@ msgid ""
 "the number of workers should be higher than the number of workers for :class:"
 "`ProcessPoolExecutor`."
 msgstr ""
+"如果 *max_workers* 為 ``None`` 或未給定，它將預設為機器上的處理器數量乘以 "
+"``5``，這假定了 :class:`ThreadPoolExecutor` 通常用於 I/O 重疊而非 CPU 密集的"
+"作業，並且 worker 的數量應該高於 :class:`ProcessPoolExecutor` 的 worker 數"
+"量。"
 
 #: ../../library/concurrent.futures.rst:174
 msgid ""
@@ -222,6 +284,8 @@ msgid ""
 "class:`threading.Thread` names for worker threads created by the pool for "
 "easier debugging."
 msgstr ""
+"新增了 *thread_name_prefix* 引數以允許使用者控制由池所建立的工作執行緒 "
+"(worker thread) 的 :class:`threading.Thread` 名稱，以便於除錯。"
 
 #: ../../library/concurrent.futures.rst:179
 #: ../../library/concurrent.futures.rst:281
@@ -235,12 +299,17 @@ msgid ""
 "It utilizes at most 32 CPU cores for CPU bound tasks which release the GIL. "
 "And it avoids using very large resources implicitly on many-core machines."
 msgstr ""
+"*max_workers* 的預設值改為 ``min(32, os.cpu_count() + 4)``。此預設值為 I/O 密"
+"集任務至少保留了 5 個 worker。它最多使用 32 個 CPU 核心來執行CPU 密集任務，以"
+"釋放 GIL。並且它避免了在多核機器上隱晦地使用非常大量的資源。"
 
 #: ../../library/concurrent.futures.rst:188
 msgid ""
 "ThreadPoolExecutor now reuses idle worker threads before starting "
 "*max_workers* worker threads too."
 msgstr ""
+"ThreadPoolExecutor 現在在啟動 *max_workers* 工作執行緒之前會重用 (reuse) 空閒"
+"的工作執行緒。"
 
 #: ../../library/concurrent.futures.rst:195
 msgid "ThreadPoolExecutor Example"
@@ -259,6 +328,11 @@ msgid ""
 "lock>` but also means that only picklable objects can be executed and "
 "returned."
 msgstr ""
+":class:`ProcessPoolExecutor` 類別是一個 :class:`Executor` 的子類別，它使用行"
+"程池來非同步地執行呼叫。:class:`ProcessPoolExecutor` 使用了 :mod:"
+"`multiprocessing` 模組，這允許它避開\\ :term:`全域直譯器鎖 (Global "
+"Interpreter Lock) <global interpreter lock>`，但也意味著只能執行和回傳可被 "
+"pickle 的 (picklable) 物件。"
 
 #: ../../library/concurrent.futures.rst:236
 msgid ""
@@ -266,12 +340,17 @@ msgid ""
 "means that :class:`ProcessPoolExecutor` will not work in the interactive "
 "interpreter."
 msgstr ""
+"``__main__`` 模組必須可以被工作子行程 (worker subprocess) 引入。這意味著 :"
+"class:`ProcessPoolExecutor` 將無法在交互式直譯器 (interactive interpreter) 中"
+"工作。"
 
 #: ../../library/concurrent.futures.rst:239
 msgid ""
 "Calling :class:`Executor` or :class:`Future` methods from a callable "
 "submitted to a :class:`ProcessPoolExecutor` will result in deadlock."
 msgstr ""
+"從提交給 :class:`ProcessPoolExecutor` 的可呼叫物件中呼叫 :class:`Executor` "
+"或 :class:`Future` 方法將導致死鎖。"
 
 #: ../../library/concurrent.futures.rst:244
 msgid ""
@@ -286,6 +365,14 @@ msgid ""
 "None. It will be used to launch the workers. If *mp_context* is ``None`` or "
 "not given, the default multiprocessing context is used."
 msgstr ""
+"一個 :class:`Executor` 子類別，它使用了最多有 *max_workers* 個行程的池來非同"
+"步地執行呼叫。如果 *max_workers* 為 ``None`` 或未給定，它將被預設為機器上的處"
+"理器數量。如果 *max_workers* 小於或等於 ``0``，則會引發 :exc:`ValueError`。"
+"在 Windows 上，*max_workers* 必須小於或等於 ``61``。如果不是，則會引發 :exc:"
+"`ValueError`。如果 *max_workers* 為 ``None``，則預設選擇最多為 ``61``，即便有"
+"更多處理器可用。*mp_context* 可以是 multiprocessing 情境 (context) 或 None。"
+"它將用於啟動 worker。如果 *mp_context* 為 ``None`` 或未給定，則使用預設的 "
+"multiprocessing 情境。"
 
 #: ../../library/concurrent.futures.rst:257
 msgid ""
@@ -295,6 +382,10 @@ msgid ""
 "jobs will raise a :exc:`~concurrent.futures.process.BrokenProcessPool`, as "
 "well as any attempt to submit more jobs to the pool."
 msgstr ""
+"*initializer* 是一個可選的可呼叫物件，在每個工作行程 (worker process) 開始時"
+"呼叫；*initargs* 是傳遞給 initializer 的引數元組。如果 *initializer* 引發例"
+"外，所有當前未定的作業以及任何向池中提交更多作業的嘗試都將引發 :exc:"
+"`~concurrent.futures.process.BrokenProcessPool`。"
 
 #: ../../library/concurrent.futures.rst:263
 msgid ""
@@ -306,6 +397,11 @@ msgid ""
 "default in absence of a *mp_context* parameter. This feature is incompatible "
 "with the \"fork\" start method."
 msgstr ""
+"*max_tasks_per_child* 是一個可選引數，它指定單個行程在退出並被新的工作行程替"
+"換之前可以執行的最大任務數。預設情況下 *max_tasks_per_child* 是 ``None``，這"
+"意味著工作行程的生命週期將與池一樣長。當指定最大值時，在沒有 *mp_context* 參"
+"數的情況下，將預設使用 \"spawn\" 做為 multiprocessing 啟動方法。此功能與 "
+"\"fork\" 啟動方法不相容。"
 
 #: ../../library/concurrent.futures.rst:271
 msgid ""
@@ -314,18 +410,23 @@ msgid ""
 "undefined but operations on the executor or its futures would often freeze "
 "or deadlock."
 msgstr ""
+"當其中一個工作行程突然終止時，現在會引發 :exc:`BrokenProcessPool` 錯誤。在過"
+"去，此行為是未定義的 (undefined)，但對 executor 或其 future 的操作經常會發生"
+"凍結或死鎖。"
 
 #: ../../library/concurrent.futures.rst:277
 msgid ""
 "The *mp_context* argument was added to allow users to control the "
 "start_method for worker processes created by the pool."
 msgstr ""
+"新增了 *mp_context* 引數以允許使用者控制由池所建立的工作行程的 start_method。"
 
 #: ../../library/concurrent.futures.rst:283
 msgid ""
 "The *max_tasks_per_child* argument was added to allow users to control the "
 "lifetime of workers in the pool."
 msgstr ""
+"新增了 *max_tasks_per_child* 引數以允許使用者控制池中 worker 的生命週期。"
 
 #: ../../library/concurrent.futures.rst:291
 msgid "ProcessPoolExecutor Example"
@@ -333,13 +434,15 @@ msgstr "ProcessPoolExecutor 範例"
 
 #: ../../library/concurrent.futures.rst:329
 msgid "Future Objects"
-msgstr ""
+msgstr "Future 物件"
 
 #: ../../library/concurrent.futures.rst:331
 msgid ""
 "The :class:`Future` class encapsulates the asynchronous execution of a "
 "callable. :class:`Future` instances are created by :meth:`Executor.submit`."
 msgstr ""
+":class:`Future` 類別封裝了可呼叫物件的非同步執行。:class:`Future` 實例由 :"
+"meth:`Executor.submit` 建立。"
 
 #: ../../library/concurrent.futures.rst:336
 msgid ""
@@ -347,6 +450,8 @@ msgid ""
 "instances are created by :meth:`Executor.submit` and should not be created "
 "directly except for testing."
 msgstr ""
+"封裝可呼叫物件的非同步執行。:class:`Future` 實例由 :meth:`Executor.submit` 建"
+"立，且除測試外不應直接建立。"
 
 #: ../../library/concurrent.futures.rst:342
 msgid ""
@@ -355,21 +460,23 @@ msgid ""
 "``False``, otherwise the call will be cancelled and the method will return "
 "``True``."
 msgstr ""
+"嘗試取消呼叫。如果呼叫當前正在執行或已完成運行且無法取消，則該方法將回傳 "
+"``False``，否則呼叫將被取消並且該方法將回傳 ``True``。"
 
 #: ../../library/concurrent.futures.rst:349
 msgid "Return ``True`` if the call was successfully cancelled."
-msgstr ""
+msgstr "如果該呼叫成功被取消，則回傳 ``True``。"
 
 #: ../../library/concurrent.futures.rst:353
 msgid ""
 "Return ``True`` if the call is currently being executed and cannot be "
 "cancelled."
-msgstr ""
+msgstr "如果呼叫正在執行且無法取消，則回傳 ``True``。"
 
 #: ../../library/concurrent.futures.rst:358
 msgid ""
 "Return ``True`` if the call was successfully cancelled or finished running."
-msgstr ""
+msgstr "如果呼叫成功被取消或結束運行，則回傳 ``True``。"
 
 #: ../../library/concurrent.futures.rst:363
 msgid ""
@@ -379,18 +486,21 @@ msgid ""
 "can be an int or float.  If *timeout* is not specified or ``None``, there is "
 "no limit to the wait time."
 msgstr ""
+"回傳該呼叫回傳的值。如果呼叫尚未完成，則此方法將等待至多 *timeout* 秒。如果呼"
+"叫在 *timeout* 秒內未完成，則會引發 :exc:`TimeoutError`。*timeout* 可以是整數"
+"或浮點數。如果未指定 *timeout* 或為 ``None``，則等待時間就不會有限制。"
 
 #: ../../library/concurrent.futures.rst:370
 #: ../../library/concurrent.futures.rst:384
 msgid ""
 "If the future is cancelled before completing then :exc:`.CancelledError` "
 "will be raised."
-msgstr ""
+msgstr "如果 future 在完成之前被取消，那麼 :exc:`.CancelledError` 將被引發。"
 
 #: ../../library/concurrent.futures.rst:373
 msgid ""
 "If the call raised an exception, this method will raise the same exception."
-msgstr ""
+msgstr "如果該呼叫引發了例外，此方法將引發相同的例外。"
 
 #: ../../library/concurrent.futures.rst:377
 msgid ""
@@ -400,10 +510,13 @@ msgid ""
 "*timeout* can be an int or float.  If *timeout* is not specified or "
 "``None``, there is no limit to the wait time."
 msgstr ""
+"回傳該呼叫引發的例外。如果呼叫尚未完成，則此方法將等待至多 *timeout* 秒。如果"
+"呼叫在 *timeout* 秒內未完成，則會引發 :exc:`TimeoutError`。 *timeout* 可以是"
+"整數或浮點數。如果未指定 *timeout* 或為 ``None``，則等待時間就不會有限制。"
 
 #: ../../library/concurrent.futures.rst:387
 msgid "If the call completed without raising, ``None`` is returned."
-msgstr ""
+msgstr "如果呼叫在沒有引發的情況下完成，則回傳 ``None``。"
 
 #: ../../library/concurrent.futures.rst:391
 msgid ""
@@ -411,6 +524,8 @@ msgid ""
 "future as its only argument, when the future is cancelled or finishes "
 "running."
 msgstr ""
+"將可呼叫的 *fn* 附加到 future 上。當 future 被取消或完成運行時，*fn* 將被以 "
+"future 作為其唯一引數來呼叫。"
 
 #: ../../library/concurrent.futures.rst:395
 msgid ""
@@ -420,18 +535,21 @@ msgid ""
 "ignored.  If the callable raises a :exc:`BaseException` subclass, the "
 "behavior is undefined."
 msgstr ""
+"新增的可呼叫物件按新增順序呼叫，並且始終在屬於新增它們的行程的執行緒中呼叫。"
+"如果可呼叫物件引發 :exc:`Exception` 子類別，它將被記錄 (log) 並忽略。如果可呼"
+"叫物件引發 :exc:`BaseException` 子類別，該行為未定義。"
 
 #: ../../library/concurrent.futures.rst:401
 msgid ""
 "If the future has already completed or been cancelled, *fn* will be called "
 "immediately."
-msgstr ""
+msgstr "如果 future 已經完成或被取消，*fn* 將立即被呼叫。"
 
 #: ../../library/concurrent.futures.rst:404
 msgid ""
 "The following :class:`Future` methods are meant for use in unit tests and :"
 "class:`Executor` implementations."
-msgstr ""
+msgstr "以下 :class:`Future` 方法旨在用於單元測試和 :class:`Executor` 實作。"
 
 #: ../../library/concurrent.futures.rst:409
 msgid ""
@@ -439,6 +557,8 @@ msgid ""
 "before executing the work associated with the :class:`Future` and by unit "
 "tests."
 msgstr ""
+"此方法只能在與 :class:`Future` 關聯的工作被執行之前於 :class:`Executor` 實作"
+"中呼叫，或者在單元測試中呼叫。"
 
 #: ../../library/concurrent.futures.rst:413
 msgid ""
@@ -447,6 +567,9 @@ msgid ""
 "waiting on the :class:`Future` completing (i.e. through :func:`as_completed` "
 "or :func:`wait`) will be woken up."
 msgstr ""
+"如果該方法回傳 ``False`` 則 :class:`Future` 已被取消，即 :meth:`Future."
+"cancel` 被呼叫並回傳 ``True``。任何等待 :class:`Future` 完成的執行緒（即透"
+"過 :func:`as_completed` 或 :func:`wait`）將被喚醒。"
 
 #: ../../library/concurrent.futures.rst:418
 msgid ""
@@ -454,24 +577,28 @@ msgid ""
 "and has been put in the running state, i.e. calls to :meth:`Future.running` "
 "will return ``True``."
 msgstr ""
+"如果該方法回傳 ``True`` 則代表 :class:`Future` 未被取消並已進入運行狀態，意即"
+"呼叫 :meth:`Future.running` 將回傳 ``True``。"
 
 #: ../../library/concurrent.futures.rst:422
 msgid ""
 "This method can only be called once and cannot be called after :meth:`Future."
 "set_result` or :meth:`Future.set_exception` have been called."
 msgstr ""
+"此方法只能呼叫一次，且不能在呼叫 :meth:`Future.set_result` 或 :meth:`Future."
+"set_exception` 之後呼叫。"
 
 #: ../../library/concurrent.futures.rst:428
 msgid ""
 "Sets the result of the work associated with the :class:`Future` to *result*."
-msgstr ""
+msgstr "將與 :class:`Future` 關聯的工作結果設定為 *result*。"
 
 #: ../../library/concurrent.futures.rst:431
 #: ../../library/concurrent.futures.rst:444
 msgid ""
 "This method should only be used by :class:`Executor` implementations and "
 "unit tests."
-msgstr ""
+msgstr "此方法只能在 :class:`Executor` 實作中和單元測試中使用。"
 
 #: ../../library/concurrent.futures.rst:434
 #: ../../library/concurrent.futures.rst:447
@@ -479,12 +606,15 @@ msgid ""
 "This method raises :exc:`concurrent.futures.InvalidStateError` if the :class:"
 "`Future` is already done."
 msgstr ""
+"如果 :class:`Future` 已經完成，此方法會引發 :exc:`concurrent.futures."
+"InvalidStateError`。"
 
 #: ../../library/concurrent.futures.rst:441
 msgid ""
 "Sets the result of the work associated with the :class:`Future` to the :"
 "class:`Exception` *exception*."
 msgstr ""
+"將與 :class:`Future` 關聯的工作結果設定為 :class:`Exception` *exception*。"
 
 #: ../../library/concurrent.futures.rst:453
 msgid "Module Functions"
@@ -500,6 +630,11 @@ msgid ""
 "named ``not_done``, contains the futures that did not complete (pending or "
 "running futures)."
 msgstr ""
+"等待 *fs* 給定的 :class:`Future` 實例（可能由不同的 :class:`Executor` 實例建"
+"立）完成。提供給 *fs* 的重複 future 將被刪除，並且只會回傳一次。回傳一個集合"
+"的附名二元組 (named 2-tuple of sets)。第一組名為 ``done``，包含在等待完成之前"
+"完成的 future（已完成或被取消的 future）。第二組名為 ``not_done``，包含未完成"
+"的 future（未定或運行中的 future）。"
 
 #: ../../library/concurrent.futures.rst:465
 msgid ""
@@ -507,12 +642,14 @@ msgid ""
 "before returning.  *timeout* can be an int or float.  If *timeout* is not "
 "specified or ``None``, there is no limit to the wait time."
 msgstr ""
+"*timeout* 可用於控制回傳前等待的最大秒數。*timeout* 可以是整數或浮點數。如果"
+"未指定 *timeout* 或為 ``None``，則等待時間就沒有限制。"
 
 #: ../../library/concurrent.futures.rst:469
 msgid ""
 "*return_when* indicates when this function should return.  It must be one of "
 "the following constants:"
-msgstr ""
+msgstr "*return_when* 表示此函式應回傳的時間。它必須是以下常數之一："
 
 #: ../../library/concurrent.futures.rst:475
 msgid "Constant"
@@ -528,7 +665,7 @@ msgstr ":const:`FIRST_COMPLETED`"
 
 #: ../../library/concurrent.futures.rst:477
 msgid "The function will return when any future finishes or is cancelled."
-msgstr ""
+msgstr "當任何 future 完成或被取消時，該函式就會回傳。"
 
 #: ../../library/concurrent.futures.rst:480
 msgid ":const:`FIRST_EXCEPTION`"
@@ -540,6 +677,8 @@ msgid ""
 "If no future raises an exception then it is equivalent to :const:"
 "`ALL_COMPLETED`."
 msgstr ""
+"該函式會在任何 future 透過引發例外而完結時回傳。如果 future 沒有引發例外，那"
+"麼它等同於 :const:`ALL_COMPLETED`。"
 
 #: ../../library/concurrent.futures.rst:486
 msgid ":const:`ALL_COMPLETED`"
@@ -547,7 +686,7 @@ msgstr ":const:`ALL_COMPLETED`"
 
 #: ../../library/concurrent.futures.rst:486
 msgid "The function will return when all futures finish or are cancelled."
-msgstr ""
+msgstr "當所有 future 都完成或被取消時，該函式才會回傳。"
 
 #: ../../library/concurrent.futures.rst:492
 msgid ""
@@ -561,34 +700,42 @@ msgid ""
 "original call to :func:`as_completed`.  *timeout* can be an int or float. If "
 "*timeout* is not specified or ``None``, there is no limit to the wait time."
 msgstr ""
+"回傳由 *fs* 給定的 :class:`Future` 實例（可能由不同的 :class:`Executor` 實例"
+"建立）的疊代器，它在完成時產生 future（已完成或被取消的 future）。*fs* 給定的"
+"任何重複的 future 將只被回傳一次。呼叫 :func:`as_completed` 之前完成的任何 "
+"future 將首先產生。如果 :meth:`~iterator.__next__` 被呼叫，並且在原先呼叫 :"
+"func:`as_completed` 的 *timeout* 秒後結果仍不可用，則回傳的疊代器會引發 :exc:"
+"`TimeoutError`。*timeout* 可以是整數或浮點數。如果未指定 *timeout* 或為 "
+"``None``，則等待時間就沒有限制。"
 
 #: ../../library/concurrent.futures.rst:506
 msgid ":pep:`3148` -- futures - execute computations asynchronously"
-msgstr ""
+msgstr ":pep:`3148` -- futures - 非同步地執行運算"
 
 #: ../../library/concurrent.futures.rst:506
 msgid ""
 "The proposal which described this feature for inclusion in the Python "
 "standard library."
-msgstr ""
+msgstr "描述此功能並提出被包含於 Python 標準函式庫中的提案。"
 
 #: ../../library/concurrent.futures.rst:511
 msgid "Exception classes"
-msgstr ""
+msgstr "例外類別"
 
 #: ../../library/concurrent.futures.rst:517
 msgid "Raised when a future is cancelled."
-msgstr ""
+msgstr "當 future 被取消時引發。"
 
 #: ../../library/concurrent.futures.rst:521
 msgid ""
 "A deprecated alias of :exc:`TimeoutError`, raised when a future operation "
 "exceeds the given timeout."
 msgstr ""
+":exc:`TimeoutError` 的棄用別名，在 future 操作超過給定超時 (timeout) 時引發。"
 
 #: ../../library/concurrent.futures.rst:526
 msgid "This class was made an alias of :exc:`TimeoutError`."
-msgstr ""
+msgstr "這個類別是 :exc:`TimeoutError` 的別名。"
 
 #: ../../library/concurrent.futures.rst:531
 msgid ""
@@ -596,12 +743,14 @@ msgid ""
 "executor is broken for some reason, and cannot be used to submit or execute "
 "new tasks."
 msgstr ""
+"衍生自 :exc:`RuntimeError`，當執行器因某種原因損壞時會引發此例外類別，並且不"
+"能用於提交或執行新任務。"
 
 #: ../../library/concurrent.futures.rst:539
 msgid ""
 "Raised when an operation is performed on a future that is not allowed in the "
 "current state."
-msgstr ""
+msgstr "當前狀態下不允許的 future 操作被執行時而引發。"
 
 #: ../../library/concurrent.futures.rst:548
 msgid ""
@@ -609,6 +758,8 @@ msgid ""
 "is raised when one of the workers of a :class:`ThreadPoolExecutor` has "
 "failed initializing."
 msgstr ""
+"衍生自 :exc:`~concurrent.futures.BrokenExecutor`，當 :class:"
+"`ThreadPoolExecutor` 的其中一個 worker 初始化失敗時會引發此例外類別。"
 
 #: ../../library/concurrent.futures.rst:558
 msgid ""
@@ -617,3 +768,6 @@ msgid ""
 "a :class:`ProcessPoolExecutor` has terminated in a non-clean fashion (for "
 "example, if it was killed from the outside)."
 msgstr ""
+"衍生自 :exc:`~concurrent.futures.BrokenExecutor`\\（以前為 :exc:"
+"`RuntimeError`），當 :class:`ProcessPoolExecutor` 的其中一個 worker 以不乾淨"
+"的方式終止時將引發此例外類別（例如它是從外面被 kill 掉的）。"

--- a/library/intro.po
+++ b/library/intro.po
@@ -146,7 +146,7 @@ msgstr ""
 
 #: ../../library/intro.rst:71
 msgid "WebAssembly platforms"
-msgstr ""
+msgstr "WebAssembly 平台"
 
 #: ../../library/intro.rst:73
 msgid ""


### PR DESCRIPTION
resolve #152

preview:

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/24987826/214133943-c9ef4678-fa3a-411a-b3cf-94e25a3b737c.png">
