### PR TITLE
Adds and refines the translations of library/statistics.po

### DIFF
--- a/library/statistics.po
+++ b/library/statistics.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Python 3.11\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-05-03 00:17+0000\n"
-"PO-Revision-Date: 2023-07-01 12:20+0800\n"
+"PO-Revision-Date: 2023-07-01 15:29+0800\n"
 "Last-Translator: Adrian Liaw <adrianliaw2000@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -97,7 +97,7 @@ msgstr ":func:`geometric_mean`"
 
 #: ../../library/statistics.rst:76
 msgid "Geometric mean of data."
-msgstr "資料中的幾何平均數。"
+msgstr "資料的幾何平均數。"
 
 #: ../../library/statistics.rst:77
 msgid ":func:`harmonic_mean`"
@@ -137,7 +137,7 @@ msgstr ":func:`median_grouped`"
 
 #: ../../library/statistics.rst:81
 msgid "Median, or 50th percentile, of grouped data."
-msgstr "分組資料的中位數或50%處。"
+msgstr "分組資料的中位數或 50% 處。"
 
 #: ../../library/statistics.rst:82
 msgid ":func:`mode`"
@@ -146,7 +146,8 @@ msgstr ":func:`mode`"
 #: ../../library/statistics.rst:82
 msgid "Single mode (most common value) of discrete or nominal data."
 msgstr ""
-"離散 (discrete) 或名目 (nomial) 資料中的眾數（出現次數最多次），只回傳一個。"
+"離散 (discrete) 或名目 (nomial) 資料中的眾數（出現次數最多次的值），只回傳一"
+"個。"
 
 #: ../../library/statistics.rst:83
 msgid ":func:`multimode`"
@@ -154,7 +155,7 @@ msgstr ":func:`multimode`"
 
 #: ../../library/statistics.rst:83
 msgid "List of modes (most common values) of discrete or nominal data."
-msgstr "離散或名目資料中的眾數（出現次數最多次）組成的 list。"
+msgstr "離散或名目資料中的眾數（出現次數最多次的值）組成的 list。"
 
 #: ../../library/statistics.rst:84
 msgid ":func:`quantiles`"

--- a/library/statistics.po
+++ b/library/statistics.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Python 3.11\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-05-03 00:17+0000\n"
-"PO-Revision-Date: 2018-07-27 16:57+0800\n"
+"PO-Revision-Date: 2023-07-01 12:20+0800\n"
 "Last-Translator: Adrian Liaw <adrianliaw2000@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 2.1.1\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #: ../../library/statistics.rst:2
 msgid ":mod:`statistics` --- Mathematical statistics functions"
@@ -81,7 +81,7 @@ msgstr ":func:`mean`"
 
 #: ../../library/statistics.rst:74
 msgid "Arithmetic mean (\"average\") of data."
-msgstr "數據的算術平均（平均值）。"
+msgstr "資料的算術平均數（平均值）。"
 
 #: ../../library/statistics.rst:75
 msgid ":func:`fmean`"
@@ -89,7 +89,7 @@ msgstr ":func:`fmean`"
 
 #: ../../library/statistics.rst:75
 msgid "Fast, floating point arithmetic mean, with optional weighting."
-msgstr ""
+msgstr "快速浮點數算數平均數，可調整權重。"
 
 #: ../../library/statistics.rst:76
 msgid ":func:`geometric_mean`"
@@ -97,7 +97,7 @@ msgstr ":func:`geometric_mean`"
 
 #: ../../library/statistics.rst:76
 msgid "Geometric mean of data."
-msgstr "數據中的幾何平均數。"
+msgstr "資料中的幾何平均數。"
 
 #: ../../library/statistics.rst:77
 msgid ":func:`harmonic_mean`"
@@ -105,7 +105,7 @@ msgstr ":func:`harmonic_mean`"
 
 #: ../../library/statistics.rst:77
 msgid "Harmonic mean of data."
-msgstr ""
+msgstr "資料的調和平均數"
 
 #: ../../library/statistics.rst:78
 msgid ":func:`median`"
@@ -113,7 +113,7 @@ msgstr ":func:`median`"
 
 #: ../../library/statistics.rst:78
 msgid "Median (middle value) of data."
-msgstr "數據的中位數（中間值）。"
+msgstr "資料的中位數（中間值）。"
 
 #: ../../library/statistics.rst:79
 msgid ":func:`median_low`"
@@ -121,7 +121,7 @@ msgstr ":func:`median_low`"
 
 #: ../../library/statistics.rst:79
 msgid "Low median of data."
-msgstr "數據中較小的中位數。"
+msgstr "資料中較小的中位數。"
 
 #: ../../library/statistics.rst:80
 msgid ":func:`median_high`"
@@ -129,7 +129,7 @@ msgstr ":func:`median_high`"
 
 #: ../../library/statistics.rst:80
 msgid "High median of data."
-msgstr "數據中較大的中位數。"
+msgstr "資料中較大的中位數。"
 
 #: ../../library/statistics.rst:81
 msgid ":func:`median_grouped`"
@@ -137,25 +137,24 @@ msgstr ":func:`median_grouped`"
 
 #: ../../library/statistics.rst:81
 msgid "Median, or 50th percentile, of grouped data."
-msgstr "分組數據的中位數或50%處。"
+msgstr "分組資料的中位數或50%處。"
 
 #: ../../library/statistics.rst:82
 msgid ":func:`mode`"
 msgstr ":func:`mode`"
 
 #: ../../library/statistics.rst:82
-#, fuzzy
 msgid "Single mode (most common value) of discrete or nominal data."
-msgstr "離散資料中的眾數（出現次數最多次）。"
+msgstr ""
+"離散 (discrete) 或名目 (nomial) 資料中的眾數（出現次數最多次），只回傳一個。"
 
 #: ../../library/statistics.rst:83
 msgid ":func:`multimode`"
 msgstr ":func:`multimode`"
 
 #: ../../library/statistics.rst:83
-#, fuzzy
 msgid "List of modes (most common values) of discrete or nominal data."
-msgstr "離散資料中的眾數（出現次數最多次）。"
+msgstr "離散或名目資料中的眾數（出現次數最多次）組成的 list。"
 
 #: ../../library/statistics.rst:84
 msgid ":func:`quantiles`"
@@ -181,7 +180,7 @@ msgstr ":func:`pstdev`"
 
 #: ../../library/statistics.rst:94
 msgid "Population standard deviation of data."
-msgstr "數據的母體標準差"
+msgstr "資料的母體標準差"
 
 #: ../../library/statistics.rst:95
 msgid ":func:`pvariance`"
@@ -189,7 +188,7 @@ msgstr ":func:`pvariance`"
 
 #: ../../library/statistics.rst:95
 msgid "Population variance of data."
-msgstr "數據的母體變異數"
+msgstr "資料的母體變異數"
 
 #: ../../library/statistics.rst:96
 msgid ":func:`stdev`"
@@ -197,7 +196,7 @@ msgstr ":func:`stdev`"
 
 #: ../../library/statistics.rst:96
 msgid "Sample standard deviation of data."
-msgstr "數據的樣本標準差"
+msgstr "資料的樣本標準差"
 
 #: ../../library/statistics.rst:97
 msgid ":func:`variance`"
@@ -205,7 +204,7 @@ msgstr ":func:`variance`"
 
 #: ../../library/statistics.rst:97
 msgid "Sample variance of data."
-msgstr "數據的樣本變異數"
+msgstr "資料的樣本變異數"
 
 #: ../../library/statistics.rst:101
 msgid "Statistics for relations between two inputs"


### PR DESCRIPTION
Adds and refines the translations of `library/statistics.po`

- 為了一致性，data一律改為臺灣較習慣的用詞「資料」
- 修正fuzzy
- 翻譯部份尚未翻譯之字串