### PR TITLE
Translate methods and properties

### DIFF
--- a/library/pathlib.po
+++ b/library/pathlib.po
@@ -1,5 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2001-2022, Python Software Foundation
+# Copyright (C) 2001-2023, Python Software Foundation
 # This file is distributed under the same license as the Python package.
 #
 # Translators:
@@ -7,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.12\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 22:55+0800\n"
-"PO-Revision-Date: 2023-07-11 01:08+0800\n"
-"Last-Translator: Adrian Liaw <adrianliaw2000@gmail.com>\n"
+"POT-Creation-Date: 2023-04-24 00:16+0000\n"
+"PO-Revision-Date: 2023-07-09 23:03+0800\n"
+"Last-Translator: Matt Wang <mattwang44@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
 "Language: zh_TW\n"
@@ -119,9 +118,7 @@ msgid ""
 "creates either a :class:`PurePosixPath` or a :class:`PureWindowsPath`)::"
 msgstr ""
 "一個通用的類別，表示系統的路徑類型（實例化時會建立一個 :class:"
-"`PurePosixPath` 或 :class:`PureWindowsPath`)：\n"
-"\n"
-"::"
+"`PurePosixPath` 或 :class:`PureWindowsPath`)： ::"
 
 #: ../../library/pathlib.rst:108
 msgid ""
@@ -132,16 +129,11 @@ msgid ""
 msgstr ""
 "*pathsegments* 中的每個元素可以是以下的其中一種：一個表示路徑片段的字串或實作"
 "了 :class:`os.PathLike` 介面 (interface) 且 :meth:`~os.PathLike.__fspath__` "
-"方法會回傳字串的物件，像是另一個路徑物件：\n"
-"\n"
-"::"
+"方法會回傳字串的物件，像是另一個路徑物件： ::"
 
 #: ../../library/pathlib.rst:118
 msgid "When *pathsegments* is empty, the current directory is assumed::"
-msgstr ""
-"當 *pathsegments* 是空的時候，預設使用目前的目錄：\n"
-"\n"
-"::"
+msgstr "當 *pathsegments* 是空的時候，預設使用目前的目錄： ::"
 
 #: ../../library/pathlib.rst:123
 msgid ""
@@ -149,9 +141,7 @@ msgid ""
 "func:`os.path.join`)::"
 msgstr ""
 "如果一個片段是絕對路徑，則所有先前的片段將被忽略（類似於 :func:`os.path."
-"join`)：\n"
-"\n"
-"::"
+"join`)： ::"
 
 #: ../../library/pathlib.rst:131
 msgid ""
@@ -159,9 +149,7 @@ msgid ""
 "g., ``r'\\foo'``) is encountered::"
 msgstr ""
 "在 Windows 系統上，當遇到具有根目錄的相對路徑片段（例如 ``r'\\foo'``）時，磁"
-"碟機 (drive) 部分不會被重置：\n"
-"\n"
-"::"
+"碟機 (drive) 部分不會被重置： ::"
 
 #: ../../library/pathlib.rst:137
 msgid ""
@@ -171,9 +159,7 @@ msgid ""
 msgstr ""
 "不必要的斜線和單點會被合併，但雙點 (``'..'``) 和前置的雙斜線 (``'//'``) 不會"
 "被合併，因為這樣會因為各種原因改變路徑的意義（例如符號連結 (symbolic links)、"
-"UNC 路徑）：\n"
-"\n"
-"::"
+"UNC 路徑）： ::"
 
 #: ../../library/pathlib.rst:150
 msgid ""
@@ -202,9 +188,7 @@ msgid ""
 "filesystem paths::"
 msgstr ""
 ":class:`PurePath` 的一個子類別 (subclass)，該路徑類型表示非 Windows 檔案系統"
-"的路徑：\n"
-"\n"
-"::"
+"的路徑： ::"
 
 #: ../../library/pathlib.rst:168 ../../library/pathlib.rst:180
 #: ../../library/pathlib.rst:739 ../../library/pathlib.rst:749
@@ -218,9 +202,7 @@ msgid ""
 "filesystem paths, including `UNC paths`_::"
 msgstr ""
 ":class:`PurePath` 的一個子類別，該路徑類型表示 Windows 檔案系統的路徑，包括  "
-"`UNC paths`_：\n"
-"\n"
-"::"
+"`UNC paths`_： ::"
 
 #: ../../library/pathlib.rst:184
 msgid ""
@@ -307,27 +289,29 @@ msgstr ""
 
 #: ../../library/pathlib.rst:287
 msgid "Methods and properties"
-msgstr ""
+msgstr "方法 (Method) 與特性 (Property)"
 
 #: ../../library/pathlib.rst:293
 msgid "Pure paths provide the following methods and properties:"
-msgstr ""
+msgstr "純路徑提供以下方法與特性："
 
 #: ../../library/pathlib.rst:297
 msgid "A string representing the drive letter or name, if any::"
 msgstr ""
+"若存在則為一個表示磁碟機字母 (drive letter) 或磁碟機名稱 (drive name) 的字"
+"串： ::"
 
 #: ../../library/pathlib.rst:306
 msgid "UNC shares are also considered drives::"
-msgstr ""
+msgstr "UNC shares 也被視為磁碟機： ::"
 
 #: ../../library/pathlib.rst:313
 msgid "A string representing the (local or global) root, if any::"
-msgstr ""
+msgstr "若存在則為一個表示（局部或全域）根目錄的字串： ::"
 
 #: ../../library/pathlib.rst:322
 msgid "UNC shares always have a root::"
-msgstr ""
+msgstr "UNC shares 都會有一個根目錄： ::"
 
 #: ../../library/pathlib.rst:327
 msgid ""
@@ -971,17 +955,11 @@ msgstr ""
 
 #: ../../library/pathlib.rst:1201
 msgid "Return the binary contents of the pointed-to file as a bytes object::"
-msgstr ""
-"將指向檔案的二進為內容以一個位元組 (bytes) 物件回傳：\n"
-"\n"
-"::"
+msgstr "將指向檔案的二進為內容以一個位元組 (bytes) 物件回傳： ::"
 
 #: ../../library/pathlib.rst:1214
 msgid "Return the decoded contents of the pointed-to file as a string::"
-msgstr ""
-"將指向檔案的解碼內容以字串形式回傳：\n"
-"\n"
-"::"
+msgstr "將指向檔案的解碼內容以字串形式回傳： ::"
 
 #: ../../library/pathlib.rst:1222
 msgid ""
@@ -993,10 +971,7 @@ msgstr "該檔案被打開並且隨後關閉。選填參數的含義與 :func:`o
 msgid ""
 "Return the path to which the symbolic link points (as returned by :func:`os."
 "readlink`)::"
-msgstr ""
-"回傳符號連結指向的路徑（如 :func:`os.readlink` 的回傳值）：\n"
-"\n"
-"::"
+msgstr "回傳符號連結指向的路徑（如 :func:`os.readlink` 的回傳值）： ::"
 
 #: ../../library/pathlib.rst:1243
 msgid ""
@@ -1009,9 +984,7 @@ msgstr ""
 "將此檔案或目錄重新命名為所提供的 *target* ，並回傳一個新的路徑 (Path) 物件指"
 "向該 *target* 。在 Unix 系統上，若 *target* 存在且為一個檔案，若使用者有權"
 "限，則會在不顯示訊息的情況下進行取代。在 Windows 系統上，若 *target* 存在，則"
-"會引發 :exc:`FileExistsError` 錯誤。*target* 可以是字串或另一個路徑物件：\n"
-"\n"
-"::"
+"會引發 :exc:`FileExistsError` 錯誤。*target* 可以是字串或另一個路徑物件： ::"
 
 #: ../../library/pathlib.rst:1258 ../../library/pathlib.rst:1274
 msgid ""
@@ -1046,27 +1019,19 @@ msgid ""
 "Make the path absolute, without normalization or resolving symlinks. Returns "
 "a new path object::"
 msgstr ""
-"使路徑成為絕對路徑，不進行標準化或解析符號連結。 回傳一個新的路徑物件：\n"
-"\n"
-"::"
+"使路徑成為絕對路徑，不進行標準化或解析符號連結。 回傳一個新的路徑物件： ::"
 
 #: ../../library/pathlib.rst:1296
 msgid ""
 "Make the path absolute, resolving any symlinks.  A new path object is "
 "returned::"
-msgstr ""
-"將路徑轉換為絕對路徑，解析所有符號連結。回傳一個新的路徑物件：\n"
-"\n"
-"::"
+msgstr "將路徑轉換為絕對路徑，解析所有符號連結。回傳一個新的路徑物件： ::"
 
 #: ../../library/pathlib.rst:1305
 msgid ""
 "\"``..``\" components are also eliminated (this is the only method to do "
 "so)::"
-msgstr ""
-"同時也會消除 \"``..``\" 的路徑組件（這是唯一的方法）：\n"
-"\n"
-"::"
+msgstr "同時也會消除 \"``..``\" 的路徑組件（這是唯一的方法）： ::"
 
 #: ../../library/pathlib.rst:1311
 msgid ""
@@ -1093,9 +1058,7 @@ msgid ""
 msgstr ""
 "遞迴地 glob 給定的相對 *pattern*。這相當於在給定的相對 *pattern* 前面加上 "
 "\"``**/``\" 並呼叫 :func:`Path.glob`，其中 *patterns* 和 :mod:`fnmatch` 相"
-"同：\n"
-"\n"
-"::"
+"同： ::"
 
 #: ../../library/pathlib.rst:1338
 msgid ""


### PR DESCRIPTION
Hi everybody, 

I translated the "Methods and Properties" section.

It includes the following sentence:

'''
Methods and properties
Pure paths provide the following methods and properties:
A string representing the drive letter or name, if any::
UNC shares are also considered drives::
A string representing the (local or global) root, if any::
'''
