### PR TITLE
fix(Makefile): use the sphinx version <7.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(VENV)/bin/activate:
 
 
 $(VENV)/bin/sphinx-build: $(VENV)/bin/activate
-	. $(VENV)/bin/activate; python3 -m pip install sphinx python-docs-theme
+	. $(VENV)/bin/activate; python3 -m pip install "sphinx<7.2.0" python-docs-theme
 
 
 $(VENV)/bin/blurb: $(VENV)/bin/activate
@@ -76,7 +76,7 @@ $(VENV)/bin/blurb: $(VENV)/bin/activate
 
 .PHONY: upgrade_venv
 upgrade_venv: $(VENV)/bin/activate ## Upgrade the venv that compiles the doc
-	. $(VENV)/bin/activate; python3 -m pip install --upgrade sphinx python-docs-theme blurb
+	. $(VENV)/bin/activate; python3 -m pip install --upgrade "sphinx<7.2.0" python-docs-theme blurb
 
 
 .PHONY: progress


### PR DESCRIPTION
CI always failed since yesterday and the error messages are all the same:
![image](https://github.com/python/python-docs-zh-tw/assets/24987826/6db7e5d2-337c-4760-9d96-5715ba811b92)

The root cause is that Sphinx 7.2.0 has been released yesterday and the `noindex` directive has been renamed to `no-index`, which is not backward-compatible.
