### PR TITLE
Translate library/typing.po from 'Intro' to 'Type Alias'

### DIFF
--- a/library/typing.po
+++ b/library/typing.po
@@ -340,7 +340,7 @@ msgid ""
 "The :keyword:`type` statement is new in Python 3.12. For backwards "
 "compatibility, type aliases can also be created through simple assignment::"
 msgstr ""
-":keyword:`type` 陳述句是 Python 3.12 的新功能。為了向後相容性，型別別名可以透"
+":keyword:`type` 陳述式是 Python 3.12 的新功能。為了向後相容性，型別別名可以透"
 "過簡單的賦值來建立： ::"
 
 #: ../../library/typing.rst:167

--- a/library/typing.po
+++ b/library/typing.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Python 3.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-27 00:19+0000\n"
-"PO-Revision-Date: 2023-09-04 22:12+0800\n"
+"PO-Revision-Date: 2023-09-05 14:49+0800\n"
 "Last-Translator: RockLeon <therockleona@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.3.1\n"
 
 #: ../../library/typing.rst:3
 msgid ":mod:`typing` --- Support for type hints"
@@ -34,7 +34,7 @@ msgid ""
 "etc."
 msgstr ""
 "Python 執行環境不強制要求函式與變數的型別註釋。他們可以被第三方工具使用，如："
-"型別檢查器、IDE、Linter 等。"
+"型別檢查器、IDE、linter 等。"
 
 #: ../../library/typing.rst:26
 msgid ""
@@ -42,7 +42,7 @@ msgid ""
 "specification of the typing system, see :pep:`484`. For a simplified "
 "introduction to type hints, see :pep:`483`."
 msgstr ""
-"這個模組提供執行環境可以支援型別提示。關於型別系統的原有規格，請看 :pep:"
+"這個模組提供可以支援型別提示的 runtime。關於型別系統的原有規格，請看 :pep:"
 "`484`。關於型別提示的簡易介紹，請看 :pep:`483`。"
 
 #: ../../library/typing.rst:31
@@ -94,8 +94,8 @@ msgid ""
 "\"Type System Reference\" section of `the mypy docs <https://mypy."
 "readthedocs.io/en/stable/index.html>`_"
 msgstr ""
-"`mypy 文件 <https://mypy.readthedocs.io/en/stable/index.html>`_  \\的 \"型別"
-"系統參照 (Type System Reference)\" 章節"
+"`mypy 文件 <https://mypy.readthedocs.io/en/stable/index.html>`_\\ 的 \"型別系"
+"統參考資料 (Type System Reference)\" 章節"
 
 #: ../../library/typing.rst:53
 msgid ""
@@ -131,7 +131,7 @@ msgid ""
 "number of PEPs have modified and enhanced Python's framework for type "
 "annotations:"
 msgstr ""
-"自從 :pep:`484` 及 :pep:`483` 對於型別提示的基礎介紹，多個 PEPs 針對型別註釋"
+"自從 :pep:`484` 及 :pep:`483` 對於型別提示的基礎引入，多個 PEPs 針對型別註釋"
 "的 Python 框架進行修訂及加強："
 
 #: ../../library/typing.rst:77
@@ -142,7 +142,7 @@ msgstr ":pep:`526`：變數註釋的語法"
 msgid ""
 "*Introducing* syntax for annotating variables outside of function "
 "definitions, and :data:`ClassVar`"
-msgstr "*介紹*\\在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
+msgstr "*引入*\\在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
 
 #: ../../library/typing.rst:80
 msgid ":pep:`544`: Protocols: Structural subtyping (static duck typing)"
@@ -155,163 +155,163 @@ msgid ""
 "*Introducing* :class:`Protocol` and the :func:"
 "`@runtime_checkable<runtime_checkable>` decorator"
 msgstr ""
-"*介紹* :class:`Protocol` 以及 :func:`@runtime_checkable<runtime_checkable>` "
+"*引入* :class:`Protocol` 以及 :func:`@runtime_checkable<runtime_checkable>` "
 "裝飾器 (decorator)"
 
 #: ../../library/typing.rst:83
 msgid ":pep:`585`: Type Hinting Generics In Standard Collections"
 msgstr ""
-":pep:`585`： 基礎集合中的型別提示泛型 (Type Hinting Generics In Standard "
-"Collections)"
+":pep:`585`：基礎彙集 (collection) 中的型別提示泛型 (Type Hinting Generics In "
+"Standard Collections)"
 
 #: ../../library/typing.rst:83
 msgid ""
 "*Introducing* :class:`types.GenericAlias` and the ability to use standard "
 "library classes as :ref:`generic types<types-genericalias>`"
 msgstr ""
-"*介紹* :class:`types.GenericAlias` 以及使用基礎函式庫類別 :ref:`generic "
+"*引入* :class:`types.GenericAlias` 以及使用基礎函式庫類別 :ref:`generic "
 "types<types-genericalias>` 的能力"
 
 #: ../../library/typing.rst:85
 msgid ":pep:`586`: Literal Types"
-msgstr ":pep:`586`： 文字型別"
+msgstr ":pep:`586`：文字型別"
 
 #: ../../library/typing.rst:86
 msgid "*Introducing* :data:`Literal`"
-msgstr "*介紹* :data:`Literal`"
+msgstr "*引入* :data:`Literal`"
 
 #: ../../library/typing.rst:87
 msgid ""
 ":pep:`589`: TypedDict: Type Hints for Dictionaries with a Fixed Set of Keys"
-msgstr ":pep:`589`： TypedDict：含有一組固定 (fixed) 鍵值的型別提示字典"
+msgstr ":pep:`589`：TypedDict：含有一組固定 (fixed) 鍵值的型別提示字典"
 
 #: ../../library/typing.rst:88
 msgid "*Introducing* :class:`TypedDict`"
-msgstr "*介紹*  :class:`TypedDict`"
+msgstr "*引入*  :class:`TypedDict`"
 
 #: ../../library/typing.rst:89
 msgid ":pep:`591`: Adding a final qualifier to typing"
-msgstr ":pep:`591`： 為型別新增一個最終限定符 (final qualifier)"
+msgstr ":pep:`591`：為型別新增一個最終限定符 (final qualifier)"
 
 #: ../../library/typing.rst:90
 msgid "*Introducing* :data:`Final` and the :func:`@final<final>` decorator"
-msgstr "*介紹* :data:`Final` 以及 :func:`@final<final>` 裝飾器"
+msgstr "*引入* :data:`Final` 以及 :func:`@final<final>` 裝飾器"
 
 #: ../../library/typing.rst:91
 msgid ":pep:`593`: Flexible function and variable annotations"
-msgstr ":pep:`593`： 彈性函式及變數註釋"
+msgstr ":pep:`593`：彈性函式及變數註釋"
 
 #: ../../library/typing.rst:92
 msgid "*Introducing* :data:`Annotated`"
-msgstr "*介紹* :data:`Annotated`"
+msgstr "*引入* :data:`Annotated`"
 
 #: ../../library/typing.rst:95
 msgid ":pep:`604`: Allow writing union types as ``X | Y``"
-msgstr ":pep:`604`： 允許寫入聯合型別 (union type) 為 ``X | Y``"
+msgstr ":pep:`604`：允許寫入聯集型別 (union type) 為 ``X | Y``"
 
 #: ../../library/typing.rst:94
 msgid ""
 "*Introducing* :data:`types.UnionType` and the ability to use the binary-or "
 "operator ``|`` to signify a :ref:`union of types<types-union>`"
 msgstr ""
-"*介紹* :data:`types.UnionType` 以及使用 binary-or 運算子 ``|`` 以表示 :ref:`"
-"型別聯合 <types-union>` 的能力"
+"*引入* :data:`types.UnionType` 以及使用 binary-or 運算子 ``|`` 以表示\\ :ref:"
+"`型別聯合 <types-union>`\\ 的能力"
 
 #: ../../library/typing.rst:97
 msgid ":pep:`612`: Parameter Specification Variables"
-msgstr ":pep:`612`： 參數規格變數 (Parameter Specification Variable)"
+msgstr ":pep:`612`：參數規格變數 (Parameter Specification Variable)"
 
 #: ../../library/typing.rst:98
 msgid "*Introducing* :class:`ParamSpec` and :data:`Concatenate`"
-msgstr "*介紹* :class:`ParamSpec` 及 :data:`Concatenate`"
+msgstr "*引入* :class:`ParamSpec` 及 :data:`Concatenate`"
 
 #: ../../library/typing.rst:99
 msgid ":pep:`613`: Explicit Type Aliases"
-msgstr ":pep:`613`： 顯式型別別名 (Explicit Type Alias)"
+msgstr ":pep:`613`：顯式型別別名 (Explicit Type Alias)"
 
 #: ../../library/typing.rst:100
 msgid "*Introducing* :data:`TypeAlias`"
-msgstr "*介紹* :data:`TypeAlias`"
+msgstr "*引入* :data:`TypeAlias`"
 
 #: ../../library/typing.rst:101
 msgid ":pep:`646`: Variadic Generics"
-msgstr ":pep:`646`： 可變的泛型 (Variadic Generic)"
+msgstr ":pep:`646`：可變參數泛型 (Variadic Generic)"
 
 #: ../../library/typing.rst:102
 msgid "*Introducing* :data:`TypeVarTuple`"
-msgstr "*介紹* :data:`TypeVarTuple`"
+msgstr "*引入* :data:`TypeVarTuple`"
 
 #: ../../library/typing.rst:103
 msgid ":pep:`647`: User-Defined Type Guards"
-msgstr ":pep:`647`： 使用者定義的型別護衛 (Type Guard)"
+msgstr ":pep:`647`：使用者定義的型別防護 (Type Guard)"
 
 #: ../../library/typing.rst:104
 msgid "*Introducing* :data:`TypeGuard`"
-msgstr "*介紹* :data:`TypeGuard`"
+msgstr "*引入* :data:`TypeGuard`"
 
 #: ../../library/typing.rst:105
 msgid ""
 ":pep:`655`: Marking individual TypedDict items as required or potentially "
 "missing"
-msgstr ":pep:`655`： 標記個別的 TypedDict 物件為必需的或可能遺失的"
+msgstr ":pep:`655`：標記個別的 TypedDict 物件為必需的或可能遺失的"
 
 #: ../../library/typing.rst:106
 msgid "*Introducing* :data:`Required` and :data:`NotRequired`"
-msgstr "*介紹*  :data:`Required` 和 :data:`NotRequired`"
+msgstr "*引入*  :data:`Required` 和 :data:`NotRequired`"
 
 #: ../../library/typing.rst:107
 msgid ":pep:`673`: Self type"
-msgstr ":pep:`673`： Self 型別"
+msgstr ":pep:`673`：Self 型別"
 
 #: ../../library/typing.rst:108
 msgid "*Introducing* :data:`Self`"
-msgstr "*介紹* :data:`Self`"
+msgstr "*引入* :data:`Self`"
 
 #: ../../library/typing.rst:109
 msgid ":pep:`675`: Arbitrary Literal String Type"
-msgstr ":pep:`675`： 任意字串型別 (Arbitrary Literal String Type)"
+msgstr ":pep:`675`：任意的文本字串型別 (Arbitrary Literal String Type)"
 
 #: ../../library/typing.rst:110
 msgid "*Introducing* :data:`LiteralString`"
-msgstr "*介紹* :data:`LiteralString`"
+msgstr "*引入* :data:`LiteralString`"
 
 #: ../../library/typing.rst:111
 msgid ":pep:`681`: Data Class Transforms"
-msgstr ":pep:`681`： 資料類別轉換"
+msgstr ":pep:`681`：資料類別轉換"
 
 #: ../../library/typing.rst:112
 msgid ""
 "*Introducing* the :func:`@dataclass_transform<dataclass_transform>` decorator"
-msgstr "*介紹* :func:`@dataclass_transform<dataclass_transform>` 裝飾器"
+msgstr "*引入* :func:`@dataclass_transform<dataclass_transform>` 裝飾器"
 
 #: ../../library/typing.rst:114
 msgid ":pep:`692`: Using ``TypedDict`` for more precise ``**kwargs`` typing"
-msgstr ":pep:`692`： 為更精準的 ``**kwargs`` 型別使用 ``TypedDict``"
+msgstr ":pep:`692`：為更精準的 ``**kwargs`` 型別使用 ``TypedDict``"
 
 #: ../../library/typing.rst:114
 msgid ""
 "*Introducing* a new way of typing ``**kwargs`` with :data:`Unpack` and :data:"
 "`TypedDict`"
 msgstr ""
-"*介紹* 型別 ``**kwargs`` 的新方式 :data:`Unpack` 以及 :data:`TypedDict`"
+"*引入* 型別 ``**kwargs`` 的新方式 :data:`Unpack` 以及 :data:`TypedDict`"
 
 #: ../../library/typing.rst:116
 msgid ":pep:`695`: Type Parameter Syntax"
-msgstr ":pep:`695`： 型別參數語法"
+msgstr ":pep:`695`：型別參數語法"
 
 #: ../../library/typing.rst:117
 msgid ""
 "*Introducing* builtin syntax for creating generic functions, classes, and "
 "type aliases."
-msgstr "*介紹*\\建立泛型函式、類別、型別別名的內建語法。"
+msgstr "*引入*\\建立泛型函式、類別、型別別名的內建語法。"
 
 #: ../../library/typing.rst:119
 msgid ":pep:`698`: Adding an override decorator to typing"
-msgstr ":pep:`698`： 為型別新增可覆寫的裝飾器"
+msgstr ":pep:`698`：為型別新增可覆寫的裝飾器"
 
 #: ../../library/typing.rst:119
 msgid "*Introducing* the :func:`@override<override>` decorator"
-msgstr "*介紹* :func:`@override<override>` 裝飾器"
+msgstr "*引入* :func:`@override<override>` 裝飾器"
 
 #: ../../library/typing.rst:129
 msgid "Type aliases"
@@ -332,7 +332,7 @@ msgid ""
 "Type aliases are useful for simplifying complex type signatures. For "
 "example::"
 msgstr ""
-"類別別名對於簡化複雜的型別簽章 (complex type signature) 非常好用。舉例來"
+"型別別名對於簡化複雜的型別簽名 (complex type signature) 非常好用。舉例來"
 "說： ::"
 
 #: ../../library/typing.rst:162

--- a/library/typing.po
+++ b/library/typing.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Python 3.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-27 00:19+0000\n"
-"PO-Revision-Date: 2023-09-04 21:35+0800\n"
+"PO-Revision-Date: 2023-09-04 22:12+0800\n"
 "Last-Translator: RockLeon <therockleona@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -136,32 +136,32 @@ msgstr ""
 
 #: ../../library/typing.rst:77
 msgid ":pep:`526`: Syntax for Variable Annotations"
-msgstr ":pep:`526`: 變數註釋的語法"
+msgstr ":pep:`526`：變數註釋的語法"
 
 #: ../../library/typing.rst:77
 msgid ""
 "*Introducing* syntax for annotating variables outside of function "
 "definitions, and :data:`ClassVar`"
-msgstr "*介紹*在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
+msgstr "*介紹*\\在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
 
 #: ../../library/typing.rst:80
 msgid ":pep:`544`: Protocols: Structural subtyping (static duck typing)"
 msgstr ""
-":pep:`544`: 協定：建構式子型別 (Structural Subtyping) （靜態鴨子類型，Static "
-"Duck Typing）"
+":pep:`544`： 協定：建構式子型別 (Structural Subtyping) （靜態鴨子類型，"
+"Static Duck Typing）"
 
 #: ../../library/typing.rst:80
 msgid ""
 "*Introducing* :class:`Protocol` and the :func:"
 "`@runtime_checkable<runtime_checkable>` decorator"
 msgstr ""
-"*介紹* :class:`Protocol` 以及 func:`@runtime_checkable<runtime_checkable>` 裝"
-"飾器 (decorator)"
+"*介紹* :class:`Protocol` 以及 :func:`@runtime_checkable<runtime_checkable>` "
+"裝飾器 (decorator)"
 
 #: ../../library/typing.rst:83
 msgid ":pep:`585`: Type Hinting Generics In Standard Collections"
 msgstr ""
-":pep:`585`: 基礎集合中的型別提示泛型 (Type Hinting Generics In Standard "
+":pep:`585`： 基礎集合中的型別提示泛型 (Type Hinting Generics In Standard "
 "Collections)"
 
 #: ../../library/typing.rst:83
@@ -174,7 +174,7 @@ msgstr ""
 
 #: ../../library/typing.rst:85
 msgid ":pep:`586`: Literal Types"
-msgstr ":pep:`586`: 文字型別"
+msgstr ":pep:`586`： 文字型別"
 
 #: ../../library/typing.rst:86
 msgid "*Introducing* :data:`Literal`"
@@ -183,7 +183,7 @@ msgstr "*介紹* :data:`Literal`"
 #: ../../library/typing.rst:87
 msgid ""
 ":pep:`589`: TypedDict: Type Hints for Dictionaries with a Fixed Set of Keys"
-msgstr ":pep:`589`: TypedDict：含有一組固定 (fixed) 鍵值的型別提示字典"
+msgstr ":pep:`589`： TypedDict：含有一組固定 (fixed) 鍵值的型別提示字典"
 
 #: ../../library/typing.rst:88
 msgid "*Introducing* :class:`TypedDict`"
@@ -191,7 +191,7 @@ msgstr "*介紹*  :class:`TypedDict`"
 
 #: ../../library/typing.rst:89
 msgid ":pep:`591`: Adding a final qualifier to typing"
-msgstr ":pep:`591`: 為型別新增一個最終限定符 (final qualifier)"
+msgstr ":pep:`591`： 為型別新增一個最終限定符 (final qualifier)"
 
 #: ../../library/typing.rst:90
 msgid "*Introducing* :data:`Final` and the :func:`@final<final>` decorator"
@@ -199,7 +199,7 @@ msgstr "*介紹* :data:`Final` 以及 :func:`@final<final>` 裝飾器"
 
 #: ../../library/typing.rst:91
 msgid ":pep:`593`: Flexible function and variable annotations"
-msgstr ":pep:`593`: 彈性函式及變數註釋"
+msgstr ":pep:`593`： 彈性函式及變數註釋"
 
 #: ../../library/typing.rst:92
 msgid "*Introducing* :data:`Annotated`"
@@ -207,7 +207,7 @@ msgstr "*介紹* :data:`Annotated`"
 
 #: ../../library/typing.rst:95
 msgid ":pep:`604`: Allow writing union types as ``X | Y``"
-msgstr ":pep:`604`: 允許寫入聯合型別 (union type) 為 ``X | Y``"
+msgstr ":pep:`604`： 允許寫入聯合型別 (union type) 為 ``X | Y``"
 
 #: ../../library/typing.rst:94
 msgid ""
@@ -219,7 +219,7 @@ msgstr ""
 
 #: ../../library/typing.rst:97
 msgid ":pep:`612`: Parameter Specification Variables"
-msgstr ":pep:`612`: 參數規格變數 (Parameter Specification Variable)"
+msgstr ":pep:`612`： 參數規格變數 (Parameter Specification Variable)"
 
 #: ../../library/typing.rst:98
 msgid "*Introducing* :class:`ParamSpec` and :data:`Concatenate`"
@@ -227,7 +227,7 @@ msgstr "*介紹* :class:`ParamSpec` 及 :data:`Concatenate`"
 
 #: ../../library/typing.rst:99
 msgid ":pep:`613`: Explicit Type Aliases"
-msgstr ":pep:`613`: 顯式型別別名 (Explicit Type Alias)"
+msgstr ":pep:`613`： 顯式型別別名 (Explicit Type Alias)"
 
 #: ../../library/typing.rst:100
 msgid "*Introducing* :data:`TypeAlias`"
@@ -235,7 +235,7 @@ msgstr "*介紹* :data:`TypeAlias`"
 
 #: ../../library/typing.rst:101
 msgid ":pep:`646`: Variadic Generics"
-msgstr ":pep:`646`: 可變的泛型 (Variadic Generic)"
+msgstr ":pep:`646`： 可變的泛型 (Variadic Generic)"
 
 #: ../../library/typing.rst:102
 msgid "*Introducing* :data:`TypeVarTuple`"
@@ -243,7 +243,7 @@ msgstr "*介紹* :data:`TypeVarTuple`"
 
 #: ../../library/typing.rst:103
 msgid ":pep:`647`: User-Defined Type Guards"
-msgstr ":pep:`647`: 使用者定義的型別護衛 (Type Guard)"
+msgstr ":pep:`647`： 使用者定義的型別護衛 (Type Guard)"
 
 #: ../../library/typing.rst:104
 msgid "*Introducing* :data:`TypeGuard`"
@@ -253,7 +253,7 @@ msgstr "*介紹* :data:`TypeGuard`"
 msgid ""
 ":pep:`655`: Marking individual TypedDict items as required or potentially "
 "missing"
-msgstr ":pep:`655`: 標記個別的 TypedDict 物件為必需的或可能遺失的"
+msgstr ":pep:`655`： 標記個別的 TypedDict 物件為必需的或可能遺失的"
 
 #: ../../library/typing.rst:106
 msgid "*Introducing* :data:`Required` and :data:`NotRequired`"
@@ -261,7 +261,7 @@ msgstr "*介紹*  :data:`Required` 和 :data:`NotRequired`"
 
 #: ../../library/typing.rst:107
 msgid ":pep:`673`: Self type"
-msgstr ":pep:`673`: Self 型別"
+msgstr ":pep:`673`： Self 型別"
 
 #: ../../library/typing.rst:108
 msgid "*Introducing* :data:`Self`"
@@ -269,7 +269,7 @@ msgstr "*介紹* :data:`Self`"
 
 #: ../../library/typing.rst:109
 msgid ":pep:`675`: Arbitrary Literal String Type"
-msgstr ":pep:`675`: 任意字串型別 (Arbitrary Literal String Type)"
+msgstr ":pep:`675`： 任意字串型別 (Arbitrary Literal String Type)"
 
 #: ../../library/typing.rst:110
 msgid "*Introducing* :data:`LiteralString`"
@@ -277,7 +277,7 @@ msgstr "*介紹* :data:`LiteralString`"
 
 #: ../../library/typing.rst:111
 msgid ":pep:`681`: Data Class Transforms"
-msgstr ":pep:`681`: 資料類別轉換"
+msgstr ":pep:`681`： 資料類別轉換"
 
 #: ../../library/typing.rst:112
 msgid ""
@@ -286,7 +286,7 @@ msgstr "*介紹* :func:`@dataclass_transform<dataclass_transform>` 裝飾器"
 
 #: ../../library/typing.rst:114
 msgid ":pep:`692`: Using ``TypedDict`` for more precise ``**kwargs`` typing"
-msgstr ":pep:`692`: 為更精準的 ``**kwargs`` 型別使用 ``TypedDict``"
+msgstr ":pep:`692`： 為更精準的 ``**kwargs`` 型別使用 ``TypedDict``"
 
 #: ../../library/typing.rst:114
 msgid ""
@@ -297,17 +297,17 @@ msgstr ""
 
 #: ../../library/typing.rst:116
 msgid ":pep:`695`: Type Parameter Syntax"
-msgstr ":pep:`695`: 型別參數語法"
+msgstr ":pep:`695`： 型別參數語法"
 
 #: ../../library/typing.rst:117
 msgid ""
 "*Introducing* builtin syntax for creating generic functions, classes, and "
 "type aliases."
-msgstr "*介紹*建立泛型函式、類別、型別別名的內建語法。"
+msgstr "*介紹*\\建立泛型函式、類別、型別別名的內建語法。"
 
 #: ../../library/typing.rst:119
 msgid ":pep:`698`: Adding an override decorator to typing"
-msgstr ":pep:`698`: 為型別新增可覆寫的裝飾器"
+msgstr ":pep:`698`： 為型別新增可覆寫的裝飾器"
 
 #: ../../library/typing.rst:119
 msgid "*Introducing* the :func:`@override<override>` decorator"
@@ -323,7 +323,7 @@ msgid ""
 "an instance of :class:`TypeAliasType`. In this example, ``Vector`` and "
 "``list[float]`` will be treated equivalently by static type checkers::"
 msgstr ""
-"一個型別別名被定義來使用 keyword:`type` 陳述式，其建立了 :class:"
+"一個型別別名被定義來使用 :keyword:`type` 陳述式，其建立了 :class:"
 "`TypeAliasType` 的實例。在這個範例中，``Vector`` 及 ``list[float]`` 會被當作"
 "和靜態型別檢查器一樣同等對待： ::"
 

--- a/library/typing.po
+++ b/library/typing.po
@@ -42,8 +42,8 @@ msgid ""
 "specification of the typing system, see :pep:`484`. For a simplified "
 "introduction to type hints, see :pep:`483`."
 msgstr ""
-"這個模組提供可以支援型別提示的 runtime。關於型別系統的原有規格，請看 :pep:"
-"`484`。關於型別提示的簡易介紹，請看 :pep:`483`。"
+"這個模組提供可以支援型別提示的 runtime。關於加註型別系統的原有規格"
+"，請看 :pep:`484`。關於型別提示的簡易介紹，請看 :pep:`483`。"
 
 #: ../../library/typing.rst:31
 msgid ""
@@ -103,8 +103,8 @@ msgid ""
 "broadly apply to most Python type checkers. (Some parts may still be "
 "specific to mypy.)"
 msgstr ""
-"Python 的型別系統是基於 PEPs 進行標準化，所以這個參照 (reference) 應該在多數 "
-"Python 型別檢查器中廣為使用。（某些部分依然是特定給 mypy 使用。）"
+"Python 的加註型別系統是基於 PEPs 進行標準化，所以這個參照 (reference) "
+"應該在多數 Python 型別檢查器中廣為使用。（某些部分依然是特定給 mypy 使用。）"
 
 #: ../../library/typing.rst:59
 msgid ""
@@ -118,8 +118,8 @@ msgid ""
 "Type-checker-agnostic documentation written by the community detailing type "
 "system features, useful typing related tools and typing best practices."
 msgstr ""
-"由社群編寫的跨平台型別檢查器文件 (type-checker-agnostic) 詳細描述型別系統的功"
-"能、實用的型別衍伸工具、以及型別的最佳實踐 (best practice)。"
+"由社群編寫的跨平台型別檢查器文件 (type-checker-agnostic) 詳細描述加註型別系統"
+"的功能、實用的加註型別衍伸工具、以及加註型別的最佳實踐 (best practice)。"
 
 #: ../../library/typing.rst:65
 msgid "Relevant PEPs"
@@ -142,12 +142,12 @@ msgstr ":pep:`526`：變數註釋的語法"
 msgid ""
 "*Introducing* syntax for annotating variables outside of function "
 "definitions, and :data:`ClassVar`"
-msgstr "*引入*\\在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
+msgstr "*引入*\\ 在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
 
 #: ../../library/typing.rst:80
 msgid ":pep:`544`: Protocols: Structural subtyping (static duck typing)"
 msgstr ""
-":pep:`544`： 協定：建構式子型別 (Structural Subtyping) （靜態鴨子類型，"
+":pep:`544`： 協定：建構式子型別 (Structural Subtyping) （靜態鴨子型別，"
 "Static Duck Typing）"
 
 #: ../../library/typing.rst:80

--- a/library/typing.po
+++ b/library/typing.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Python 3.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-27 00:19+0000\n"
-"PO-Revision-Date: 2023-09-04 10:25+0800\n"
+"PO-Revision-Date: 2023-09-04 21:35+0800\n"
 "Last-Translator: RockLeon <therockleona@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
@@ -94,8 +94,8 @@ msgid ""
 "\"Type System Reference\" section of `the mypy docs <https://mypy."
 "readthedocs.io/en/stable/index.html>`_"
 msgstr ""
-"\\ `mypy 文件 <https://mypy.readthedocs.io/en/stable/index.html>`_  \\的 "
-"\"Type System Reference\" 章節"
+"`mypy 文件 <https://mypy.readthedocs.io/en/stable/index.html>`_  \\的 \"型別"
+"系統參照 (Type System Reference)\" 章節"
 
 #: ../../library/typing.rst:53
 msgid ""
@@ -103,21 +103,27 @@ msgid ""
 "broadly apply to most Python type checkers. (Some parts may still be "
 "specific to mypy.)"
 msgstr ""
+"Python 的型別系統是基於 PEPs 進行標準化，所以這個參照 (reference) 應該在多數 "
+"Python 型別檢查器中廣為使用。（某些部分依然是特定給 mypy 使用。）"
 
 #: ../../library/typing.rst:59
 msgid ""
 "`\"Static Typing with Python\" <https://typing.readthedocs.io/en/latest/>`_"
 msgstr ""
+"`\"Python 的靜態型別 (Static Typing)\" <https://typing.readthedocs.io/en/"
+"latest/>`_"
 
 #: ../../library/typing.rst:58
 msgid ""
 "Type-checker-agnostic documentation written by the community detailing type "
 "system features, useful typing related tools and typing best practices."
 msgstr ""
+"由社群編寫的跨平台型別檢查器文件 (type-checker-agnostic) 詳細描述型別系統的功"
+"能、實用的型別衍伸工具、以及型別的最佳實踐 (best practice)。"
 
 #: ../../library/typing.rst:65
 msgid "Relevant PEPs"
-msgstr ""
+msgstr "相關的 PEPs"
 
 #: ../../library/typing.rst:67
 msgid ""
@@ -125,178 +131,191 @@ msgid ""
 "number of PEPs have modified and enhanced Python's framework for type "
 "annotations:"
 msgstr ""
+"自從 :pep:`484` 及 :pep:`483` 對於型別提示的基礎介紹，多個 PEPs 針對型別註釋"
+"的 Python 框架進行修訂及加強："
 
 #: ../../library/typing.rst:77
 msgid ":pep:`526`: Syntax for Variable Annotations"
-msgstr ""
+msgstr ":pep:`526`: 變數註釋的語法"
 
 #: ../../library/typing.rst:77
 msgid ""
 "*Introducing* syntax for annotating variables outside of function "
 "definitions, and :data:`ClassVar`"
-msgstr ""
+msgstr "*介紹*在定義函式之外的變數註釋語法，以及 :data:`ClassVar`"
 
 #: ../../library/typing.rst:80
 msgid ":pep:`544`: Protocols: Structural subtyping (static duck typing)"
 msgstr ""
+":pep:`544`: 協定：建構式子型別 (Structural Subtyping) （靜態鴨子類型，Static "
+"Duck Typing）"
 
 #: ../../library/typing.rst:80
 msgid ""
 "*Introducing* :class:`Protocol` and the :func:"
 "`@runtime_checkable<runtime_checkable>` decorator"
 msgstr ""
+"*介紹* :class:`Protocol` 以及 func:`@runtime_checkable<runtime_checkable>` 裝"
+"飾器 (decorator)"
 
 #: ../../library/typing.rst:83
 msgid ":pep:`585`: Type Hinting Generics In Standard Collections"
 msgstr ""
+":pep:`585`: 基礎集合中的型別提示泛型 (Type Hinting Generics In Standard "
+"Collections)"
 
 #: ../../library/typing.rst:83
 msgid ""
 "*Introducing* :class:`types.GenericAlias` and the ability to use standard "
 "library classes as :ref:`generic types<types-genericalias>`"
 msgstr ""
+"*介紹* :class:`types.GenericAlias` 以及使用基礎函式庫類別 :ref:`generic "
+"types<types-genericalias>` 的能力"
 
 #: ../../library/typing.rst:85
 msgid ":pep:`586`: Literal Types"
-msgstr ""
+msgstr ":pep:`586`: 文字型別"
 
 #: ../../library/typing.rst:86
 msgid "*Introducing* :data:`Literal`"
-msgstr ""
+msgstr "*介紹* :data:`Literal`"
 
 #: ../../library/typing.rst:87
 msgid ""
 ":pep:`589`: TypedDict: Type Hints for Dictionaries with a Fixed Set of Keys"
-msgstr ""
+msgstr ":pep:`589`: TypedDict：含有一組固定 (fixed) 鍵值的型別提示字典"
 
 #: ../../library/typing.rst:88
 msgid "*Introducing* :class:`TypedDict`"
-msgstr ""
+msgstr "*介紹*  :class:`TypedDict`"
 
 #: ../../library/typing.rst:89
 msgid ":pep:`591`: Adding a final qualifier to typing"
-msgstr ""
+msgstr ":pep:`591`: 為型別新增一個最終限定符 (final qualifier)"
 
 #: ../../library/typing.rst:90
 msgid "*Introducing* :data:`Final` and the :func:`@final<final>` decorator"
-msgstr ""
+msgstr "*介紹* :data:`Final` 以及 :func:`@final<final>` 裝飾器"
 
 #: ../../library/typing.rst:91
 msgid ":pep:`593`: Flexible function and variable annotations"
-msgstr ""
+msgstr ":pep:`593`: 彈性函式及變數註釋"
 
 #: ../../library/typing.rst:92
 msgid "*Introducing* :data:`Annotated`"
-msgstr ""
+msgstr "*介紹* :data:`Annotated`"
 
 #: ../../library/typing.rst:95
 msgid ":pep:`604`: Allow writing union types as ``X | Y``"
-msgstr ""
+msgstr ":pep:`604`: 允許寫入聯合型別 (union type) 為 ``X | Y``"
 
 #: ../../library/typing.rst:94
 msgid ""
 "*Introducing* :data:`types.UnionType` and the ability to use the binary-or "
 "operator ``|`` to signify a :ref:`union of types<types-union>`"
 msgstr ""
+"*介紹* :data:`types.UnionType` 以及使用 binary-or 運算子 ``|`` 以表示 :ref:`"
+"型別聯合 <types-union>` 的能力"
 
 #: ../../library/typing.rst:97
 msgid ":pep:`612`: Parameter Specification Variables"
-msgstr ""
+msgstr ":pep:`612`: 參數規格變數 (Parameter Specification Variable)"
 
 #: ../../library/typing.rst:98
 msgid "*Introducing* :class:`ParamSpec` and :data:`Concatenate`"
-msgstr ""
+msgstr "*介紹* :class:`ParamSpec` 及 :data:`Concatenate`"
 
 #: ../../library/typing.rst:99
 msgid ":pep:`613`: Explicit Type Aliases"
-msgstr ""
+msgstr ":pep:`613`: 顯式型別別名 (Explicit Type Alias)"
 
 #: ../../library/typing.rst:100
 msgid "*Introducing* :data:`TypeAlias`"
-msgstr "*引入* :data:`TypeAlias`"
+msgstr "*介紹* :data:`TypeAlias`"
 
 #: ../../library/typing.rst:101
 msgid ":pep:`646`: Variadic Generics"
-msgstr ""
+msgstr ":pep:`646`: 可變的泛型 (Variadic Generic)"
 
 #: ../../library/typing.rst:102
 msgid "*Introducing* :data:`TypeVarTuple`"
-msgstr "*引入* :data:`TypeVarTuple`"
+msgstr "*介紹* :data:`TypeVarTuple`"
 
 #: ../../library/typing.rst:103
 msgid ":pep:`647`: User-Defined Type Guards"
-msgstr ""
+msgstr ":pep:`647`: 使用者定義的型別護衛 (Type Guard)"
 
 #: ../../library/typing.rst:104
 msgid "*Introducing* :data:`TypeGuard`"
-msgstr "*引入* :data:`TypeGuard`"
+msgstr "*介紹* :data:`TypeGuard`"
 
 #: ../../library/typing.rst:105
 msgid ""
 ":pep:`655`: Marking individual TypedDict items as required or potentially "
 "missing"
-msgstr ""
+msgstr ":pep:`655`: 標記個別的 TypedDict 物件為必需的或可能遺失的"
 
 #: ../../library/typing.rst:106
 msgid "*Introducing* :data:`Required` and :data:`NotRequired`"
-msgstr "*引入*  :data:`Required` 和 :data:`NotRequired`"
+msgstr "*介紹*  :data:`Required` 和 :data:`NotRequired`"
 
 #: ../../library/typing.rst:107
 msgid ":pep:`673`: Self type"
-msgstr ""
+msgstr ":pep:`673`: Self 型別"
 
 #: ../../library/typing.rst:108
 msgid "*Introducing* :data:`Self`"
-msgstr "*引入* :data:`Self`"
+msgstr "*介紹* :data:`Self`"
 
 #: ../../library/typing.rst:109
 msgid ":pep:`675`: Arbitrary Literal String Type"
-msgstr ""
+msgstr ":pep:`675`: 任意字串型別 (Arbitrary Literal String Type)"
 
 #: ../../library/typing.rst:110
 msgid "*Introducing* :data:`LiteralString`"
-msgstr "*引入* :data:`LiteralString`"
+msgstr "*介紹* :data:`LiteralString`"
 
 #: ../../library/typing.rst:111
 msgid ":pep:`681`: Data Class Transforms"
-msgstr ""
+msgstr ":pep:`681`: 資料類別轉換"
 
 #: ../../library/typing.rst:112
 msgid ""
 "*Introducing* the :func:`@dataclass_transform<dataclass_transform>` decorator"
-msgstr "*引入* :func:`@dataclass_transform<dataclass_transform>` 裝飾器"
+msgstr "*介紹* :func:`@dataclass_transform<dataclass_transform>` 裝飾器"
 
 #: ../../library/typing.rst:114
 msgid ":pep:`692`: Using ``TypedDict`` for more precise ``**kwargs`` typing"
-msgstr ""
+msgstr ":pep:`692`: 為更精準的 ``**kwargs`` 型別使用 ``TypedDict``"
 
 #: ../../library/typing.rst:114
 msgid ""
 "*Introducing* a new way of typing ``**kwargs`` with :data:`Unpack` and :data:"
 "`TypedDict`"
 msgstr ""
+"*介紹* 型別 ``**kwargs`` 的新方式 :data:`Unpack` 以及 :data:`TypedDict`"
 
 #: ../../library/typing.rst:116
 msgid ":pep:`695`: Type Parameter Syntax"
-msgstr ""
+msgstr ":pep:`695`: 型別參數語法"
 
 #: ../../library/typing.rst:117
 msgid ""
 "*Introducing* builtin syntax for creating generic functions, classes, and "
 "type aliases."
-msgstr ""
+msgstr "*介紹*建立泛型函式、類別、型別別名的內建語法。"
 
 #: ../../library/typing.rst:119
 msgid ":pep:`698`: Adding an override decorator to typing"
-msgstr ""
+msgstr ":pep:`698`: 為型別新增可覆寫的裝飾器"
 
 #: ../../library/typing.rst:119
 msgid "*Introducing* the :func:`@override<override>` decorator"
-msgstr "*引入* :func:`@override<override>` 裝飾器"
+msgstr "*介紹* :func:`@override<override>` 裝飾器"
 
 #: ../../library/typing.rst:129
 msgid "Type aliases"
-msgstr ""
+msgstr "型別別名"
 
 #: ../../library/typing.rst:131
 msgid ""
@@ -304,24 +323,33 @@ msgid ""
 "an instance of :class:`TypeAliasType`. In this example, ``Vector`` and "
 "``list[float]`` will be treated equivalently by static type checkers::"
 msgstr ""
+"一個型別別名被定義來使用 keyword:`type` 陳述式，其建立了 :class:"
+"`TypeAliasType` 的實例。在這個範例中，``Vector`` 及 ``list[float]`` 會被當作"
+"和靜態型別檢查器一樣同等對待： ::"
 
 #: ../../library/typing.rst:144
 msgid ""
 "Type aliases are useful for simplifying complex type signatures. For "
 "example::"
 msgstr ""
+"類別別名對於簡化複雜的型別簽章 (complex type signature) 非常好用。舉例來"
+"說： ::"
 
 #: ../../library/typing.rst:162
 msgid ""
 "The :keyword:`type` statement is new in Python 3.12. For backwards "
 "compatibility, type aliases can also be created through simple assignment::"
 msgstr ""
+":keyword:`type` 陳述句是 Python 3.12 的新功能。為了向後相容性，型別別名可以透"
+"過簡單的賦值來建立： ::"
 
 #: ../../library/typing.rst:167
 msgid ""
 "Or marked with :data:`TypeAlias` to make it explicit that this is a type "
 "alias, not a normal variable assignment::"
 msgstr ""
+"或是用 :data:`TypeAlias` 標記，讓它明確的表示這是一個型別別名，而非一般的變數"
+"賦值： ::"
 
 #: ../../library/typing.rst:177
 msgid "NewType"

--- a/library/typing.po
+++ b/library/typing.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: Python 3.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-27 00:19+0000\n"
-"PO-Revision-Date: 2018-05-23 16:14+0000\n"
-"Last-Translator: Adrian Liaw <adrianliaw2000@gmail.com>\n"
+"PO-Revision-Date: 2023-09-04 10:25+0800\n"
+"Last-Translator: RockLeon <therockleona@gmail.com>\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
 "Language: zh_TW\n"
@@ -17,10 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #: ../../library/typing.rst:3
 msgid ":mod:`typing` --- Support for type hints"
-msgstr ""
+msgstr ":mod:`typing` --- 支援型別提示"
 
 #: ../../library/typing.rst:16
 msgid "**Source code:** :source:`Lib/typing.py`"
@@ -32,6 +33,8 @@ msgid ""
 "They can be used by third party tools such as type checkers, IDEs, linters, "
 "etc."
 msgstr ""
+"Python 執行環境不強制要求函式與變數的型別註釋。他們可以被第三方工具使用，如："
+"型別檢查器、IDE、Linter 等。"
 
 #: ../../library/typing.rst:26
 msgid ""
@@ -39,11 +42,13 @@ msgid ""
 "specification of the typing system, see :pep:`484`. For a simplified "
 "introduction to type hints, see :pep:`483`."
 msgstr ""
+"這個模組提供執行環境可以支援型別提示。關於型別系統的原有規格，請看 :pep:"
+"`484`。關於型別提示的簡易介紹，請看 :pep:`483`。"
 
 #: ../../library/typing.rst:31
 msgid ""
 "The function below takes and returns a string and is annotated as follows::"
-msgstr ""
+msgstr "以下函式接受及回傳都是使用字串，且註解方式如下： ::"
 
 #: ../../library/typing.rst:36
 msgid ""
@@ -51,6 +56,8 @@ msgid ""
 "type :class:`str` and the return type :class:`str`. Subtypes are accepted as "
 "arguments."
 msgstr ""
+"在函式 ``greeting`` 當中，引數 ``name`` 的型別應為 :class:`str` 且回傳的型別"
+"也是 :class:`str`。該引數也可以接受其子型別。"
 
 #: ../../library/typing.rst:40
 msgid ""
@@ -58,28 +65,37 @@ msgid ""
 "`typing_extensions <https://pypi.org/project/typing-extensions/>`_ package "
 "provides backports of these new features to older versions of Python."
 msgstr ""
+"新功能會頻繁的新增至 ``typing`` 模組中。`typing_extensions <https://pypi.org/"
+"project/typing-extensions/>`_ 套件為這些新功能提供了 backport（向後移植的）版"
+"本，提供給舊版本的 Python 使用。"
 
 #: ../../library/typing.rst:44
 msgid ""
 "For a summary of deprecated features and a deprecation timeline, please see "
 "`Deprecation Timeline of Major Features`_."
 msgstr ""
+"棄用功能及其棄用時間線的簡介，請看\\ `Deprecation Timeline of Major "
+"Features`_ \\。"
 
 #: ../../library/typing.rst:50
 msgid ""
 "`\"Typing cheat sheet\" <https://mypy.readthedocs.io/en/stable/"
 "cheat_sheet_py3.html>`_"
 msgstr ""
+"`\"型別小抄 (Typing cheat sheet)\" <https://mypy.readthedocs.io/en/stable/"
+"cheat_sheet_py3.html>`_"
 
 #: ../../library/typing.rst:50
 msgid "A quick overview of type hints (hosted at the mypy docs)"
-msgstr ""
+msgstr "型別提示的快速預覽（發布於 mypy 的文件中）"
 
 #: ../../library/typing.rst:55
 msgid ""
 "\"Type System Reference\" section of `the mypy docs <https://mypy."
 "readthedocs.io/en/stable/index.html>`_"
 msgstr ""
+"\\ `mypy 文件 <https://mypy.readthedocs.io/en/stable/index.html>`_  \\的 "
+"\"Type System Reference\" 章節"
 
 #: ../../library/typing.rst:53
 msgid ""
@@ -407,9 +423,9 @@ msgstr ""
 
 #: ../../library/typing.rst:254 ../../library/typing.rst:2679
 msgid "For example:"
-msgstr "舉例來說"
+msgstr "舉例來說："
 
-#: ../../library/typing.rst:272
+#: ../../library/typing.rst:272 ../../library/typing.rst:995
 msgid ""
 "The subscription syntax must always be used with exactly two values: the "
 "argument list and the return type.  The argument list must be a list of "
@@ -990,14 +1006,6 @@ msgstr ""
 msgid ""
 "``Callable[[int], str]`` signifies a function that takes a single parameter "
 "of type :class:`int` and returns a :class:`str`."
-msgstr ""
-
-#: ../../library/typing.rst:995
-msgid ""
-"The subscription syntax must always be used with exactly two values: the "
-"argument list and the return type.  The argument list must be a list of "
-"types, a :class:`ParamSpec`, :data:`Concatenate`, or an ellipsis. The return "
-"type must be a single type."
 msgstr ""
 
 #: ../../library/typing.rst:1000

--- a/library/typing.po
+++ b/library/typing.po
@@ -303,7 +303,7 @@ msgstr ":pep:`695`：型別參數語法"
 msgid ""
 "*Introducing* builtin syntax for creating generic functions, classes, and "
 "type aliases."
-msgstr "*引入*\\建立泛型函式、類別、型別別名的內建語法。"
+msgstr "*引入*\\ 建立泛型函式、類別、型別別名的內建語法。"
 
 #: ../../library/typing.rst:119
 msgid ":pep:`698`: Adding an override decorator to typing"


### PR DESCRIPTION
#190 

<details>
<summary>Preview</summary>

![image](https://github.com/python/python-docs-zh-tw/assets/34214497/132795d2-12a6-4104-8bcc-ff3035f55fe4)

![image](https://github.com/python/python-docs-zh-tw/assets/34214497/cdec5a1d-6371-49eb-828d-55f55b42d9e2)

![image](https://github.com/python/python-docs-zh-tw/assets/34214497/04a5982b-952a-4876-a6dd-2d120e483cb3)

![image](https://github.com/python/python-docs-zh-tw/assets/34214497/332c4cbc-829f-4e59-8ae7-6477b9f8dd83)

![image](https://github.com/python/python-docs-zh-tw/assets/34214497/7b4ec721-a301-48b5-9f0f-6a912806058a)

![image](https://github.com/python/python-docs-zh-tw/assets/34214497/76acf895-72f0-4da5-819b-e9e79c8f8b1c)
</details>