### PR TITLE
Translate "Format Specification Mini-Language": `296`, `298`

### DIFF
--- a/library/string.po
+++ b/library/string.po
@@ -354,7 +354,7 @@ msgstr "範例請見 :ref:`formatexamples`\\ 。"
 
 #: ../../library/string.rst:296
 msgid "Format Specification Mini-Language"
-msgstr ""
+msgstr "格式規格 (Format Specification) 迷你語言"
 
 #: ../../library/string.rst:298
 msgid ""
@@ -364,6 +364,10 @@ msgid ""
 "to the built-in :func:`format` function.  Each formattable type may define "
 "how the format specification is to be interpreted."
 msgstr ""
+"“格式規格” 在格式字串 (format string) 中包含的替換欄位中使用，以定義各個值如"
+"何被呈現（請參考 :ref:`formatstrings` and :ref:`f-strings` ）。它們也能夠直接"
+"傳遞給內建的 :fun:`format` 函式。每個可格式化型別 (formattable type) 可以定義"
+"格式規格如何被直譯。"
 
 #: ../../library/string.rst:305
 msgid ""


### PR DESCRIPTION
目標翻譯 `rst:296`, `rst:298`

Format Specification -> 格式規格 (3.10 採用此翻譯)
format string -> 格式字串
formattable type -> 可格式化型別

因為我自己看譯文體感較難聯想到原文，傾向先以一同呈現原文的方式翻譯 Ex: "格式規格 (Format Specification)"

