### PR TITLE
Translate library/string.po rst, 2, 19, 26

### DIFF
--- a/library/string.po
+++ b/library/string.po
@@ -48,7 +48,7 @@ msgid ""
 "`ascii_uppercase` constants described below.  This value is not locale-"
 "dependent."
 msgstr ""
-"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 常數的串接。該值不依賴於區域。"
+"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 常數的串接，該值不依賴於區域設定。"
 
 #: ../../library/string.rst:32
 msgid ""

--- a/library/string.po
+++ b/library/string.po
@@ -36,7 +36,7 @@ msgstr ":ref:`string-methods`"
 
 #: ../../library/string.rst:19
 msgid "String constants"
-msgstr "字串常量"
+msgstr "字串常數"
 
 #: ../../library/string.rst:21
 msgid "The constants defined in this module are:"
@@ -48,7 +48,7 @@ msgid ""
 "`ascii_uppercase` constants described below.  This value is not locale-"
 "dependent."
 msgstr ""
-"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 常量的串接。該值不依賴於區域。"
+"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 常數的串接。該值不依賴於區域。"
 
 #: ../../library/string.rst:32
 msgid ""

--- a/library/string.po
+++ b/library/string.po
@@ -48,7 +48,7 @@ msgid ""
 "`ascii_uppercase` constants described below.  This value is not locale-"
 "dependent."
 msgstr ""
-"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 的字串串接。該值不依賴於區域。"
+"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 常量的串接。該值不依賴於區域。"
 
 #: ../../library/string.rst:32
 msgid ""

--- a/library/string.po
+++ b/library/string.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: ../../library/string.rst:2
 msgid ":mod:`string` --- Common string operations"
-msgstr ""
+msgstr ":mod:`string` --- 常見的字串操作"
 
 #: ../../library/string.rst:7
 msgid "**Source code:** :source:`Lib/string.py`"
@@ -36,7 +36,7 @@ msgstr ":ref:`string-methods`"
 
 #: ../../library/string.rst:19
 msgid "String constants"
-msgstr ""
+msgstr "字串常量"
 
 #: ../../library/string.rst:21
 msgid "The constants defined in this module are:"
@@ -48,6 +48,7 @@ msgid ""
 "`ascii_uppercase` constants described below.  This value is not locale-"
 "dependent."
 msgstr ""
+"下文描述的 :const:`ascii_lowercase` 和 :const:`ascii_uppercase` 的字串串接。該值不依賴於區域。"
 
 #: ../../library/string.rst:32
 msgid ""


### PR DESCRIPTION
- Locale 根據 Python 術語對照表的 locale encoding 翻譯為區域
- "The concatenation of xxx and xxx constants" 原先考慮過「xxx 和 xxx 的常量的字串串接。」，但目前「字串串接」修正為「串接」可能更為精簡。（這邊因為有語意上的猶豫，故紀錄以供判斷）。