### PR TITLE
fix(action): should take default branch name as the version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
         run: sudo apt-get install gettext
 
       - name: Validate
-        run: VERSION=${{ github.event.pull_request.base.ref }} MODE=dummy make all
+        run: VERSION=${{ github.event.repository.default_branch }} MODE=dummy make all


### PR DESCRIPTION
[WHY]

If the name of the target branch is not the version name, the CI workflow would fail.

[HOW]

Take the default branch name as the version.