### PR TITLE
Small fix for translations of library/io.po

### DIFF
--- a/library/io.po
+++ b/library/io.po
@@ -582,7 +582,7 @@ msgid ""
 "derived classes can override selectively; the default implementations "
 "represent a file that cannot be read, written or seeked."
 msgstr ""
-"為許多方法提供了空的抽象實作，衍伸類別可以選擇性地覆寫這些方法；預設的實作代"
+"為許多方法提供了空的抽象實作，衍生類別可以選擇性地覆寫這些方法；預設的實作代"
 "表一個無法讀取、寫入或搜尋的檔案。"
 
 #: ../../library/io.rst:323


### PR DESCRIPTION
Small fix for translations of `library/io.po`