### PR TITLE
Fix reST markup in 3.2.po

### DIFF
--- a/whatsnew/3.2.po
+++ b/whatsnew/3.2.po
@@ -1540,8 +1540,8 @@ msgid ""
 "and :issue:`2846`.)"
 msgstr ""
 "（由 Anand B. Pillai 在 :issue:`3488` 中貢獻；由 Antoine Pitrou、Nir Aides "
-"和 Brian Curtin 在 :issue:`9962`、:issue:`1675951`、:issue:`7471` 和 :issue: "
-"`2846` 中貢獻。）"
+"和 Brian Curtin 在 :issue:`9962`、:issue:`1675951`、:issue:`7471` 和 "
+":issue:`2846` 中貢獻。）"
 
 #: ../../whatsnew/3.2.rst:1430
 msgid ""


### PR DESCRIPTION
This should fix one of the two linter errors reported in #494.