### PR TITLE
fix: Change summarize_progress script to commit at wiki

### DIFF
--- a/.github/workflows/summarize_progress.yml
+++ b/.github/workflows/summarize_progress.yml
@@ -1,8 +1,11 @@
 name: summarize_progress
 
 on:
-    schedule:
-      - cron:  '30 23 * * 5'
+  push:
+    branches:
+      - 'feature/summarize'
+  schedule:
+    - cron:  '30 23 * * 5'
 
 jobs:
   ci:
@@ -23,6 +26,14 @@ jobs:
             .scripts/summarize_progress.sh
         shell: bash
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Checkout wiki code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}.wiki
+          path: markdown
+
+      - name: commit wiki code
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
             commit_message: Weekly Update -- Summarize Progress
+            repository: markdown

--- a/.github/workflows/summarize_progress.yml
+++ b/.github/workflows/summarize_progress.yml
@@ -1,9 +1,6 @@
 name: summarize_progress
 
 on:
-  push:
-    branches:
-      - 'feature/summarize'
   schedule:
     - cron:  '30 23 * * 5'
 
@@ -35,7 +32,7 @@ jobs:
       
       - name: Copy content
         run: |
-            cp .scripts/summarize_progress/dist/summarize_progress.md markdown/summarize_progess.md
+            cp .scripts/summarize_progress/dist/summarize_progress.md markdown/各檔案翻譯進度清單.md
         shell: bash
 
       - name: Commit wiki code

--- a/.github/workflows/summarize_progress.yml
+++ b/.github/workflows/summarize_progress.yml
@@ -25,14 +25,20 @@ jobs:
             chmod +x .scripts/summarize_progress.sh 
             .scripts/summarize_progress.sh
         shell: bash
+      
 
       - name: Checkout wiki code
         uses: actions/checkout@v2
         with:
           repository: ${{github.repository}}.wiki
           path: markdown
+      
+      - name: Copy content
+        run: |
+            cp .scripts/summarize_progress/dist/summarize_progress.md markdown/summarize_progess.md
+        shell: bash
 
-      - name: commit wiki code
+      - name: Commit wiki code
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
             commit_message: Weekly Update -- Summarize Progress


### PR DESCRIPTION
繼上次的 PR #706 過後有點問題，原因是因為 Branch Protection，所以不能透過 Github Action Bot 改寫內容。

這次 PR 改成寫入 Wiki，也已經測試過沒有問題，請看 [測試結果](https://github.com/rockleona/python-docs-zh-tw/wiki/summarize_progess)。