### PR TITLE
add i18n for logging

### DIFF
--- a/library/logging.po
+++ b/library/logging.po
@@ -1139,7 +1139,7 @@ msgstr ""
 #: ../../library/logging.rst:917 ../../library/logging.rst:931
 #: ../../library/logging.rst:959 ../../library/logging.rst:977
 msgid "You shouldn't need to format this yourself."
-msgstr "你不需要自己格式化它．"
+msgstr "你不需要自己格式化它。"
 
 #: ../../library/logging.rst:917
 msgid ""

--- a/library/logging.po
+++ b/library/logging.po
@@ -1139,7 +1139,7 @@ msgstr ""
 #: ../../library/logging.rst:917 ../../library/logging.rst:931
 #: ../../library/logging.rst:959 ../../library/logging.rst:977
 msgid "You shouldn't need to format this yourself."
-msgstr ""
+msgstr "你不需要自己格式化它．"
 
 #: ../../library/logging.rst:917
 msgid ""
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: ../../library/logging.rst:934
 msgid "filename"
-msgstr ""
+msgstr "filename"
 
 #: ../../library/logging.rst:934
 msgid "``%(filename)s``"
@@ -1303,7 +1303,7 @@ msgstr ""
 
 #: ../../library/logging.rst:0 ../../library/logging.rst:964
 msgid "name"
-msgstr ""
+msgstr "name"
 
 #: ../../library/logging.rst:964
 msgid "``%(name)s``"


### PR DESCRIPTION
Add I18N for logging module

## You shouldn't need to format this yourself.
* 截圖中少了符號`．`，我有補上
<img width="723" alt="Screenshot 2024-03-10 at 4 35 14 PM" src="https://github.com/python/python-docs-zh-tw/assets/13660259/220d330c-9f84-42fa-ad1e-efc0c7a02d63">

<img width="734" alt="Screenshot 2024-03-10 at 4 34 59 PM" src="https://github.com/python/python-docs-zh-tw/assets/13660259/1b66bdda-69bd-4061-b923-8beb87d57d7a">

## Name
<img width="735" alt="Screenshot 2024-03-10 at 4 36 31 PM" src="https://github.com/python/python-docs-zh-tw/assets/13660259/2b505d56-c7da-4d6a-9415-757c2521c1fb">

## Filename
<img width="793" alt="Screenshot 2024-03-10 at 4 35 57 PM" src="https://github.com/python/python-docs-zh-tw/assets/13660259/e3c87fd6-e173-48a5-aaf4-07fec51411d3">
