### PR TITLE
ci(summary): update actions/checkout to V4

### DIFF
--- a/.github/workflows/summarize_progress.yml
+++ b/.github/workflows/summarize_progress.yml
@@ -26,7 +26,7 @@ jobs:
       
 
       - name: Checkout wiki code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{github.repository}}.wiki
           path: markdown


### PR DESCRIPTION
Since this CI workflow failed for 3 weeks, I found the error came from `actions/checkout`, Version 2 cannot checkout for wiki's default branch, then I do an upgrade to Version 4 and it works perfectly again.


References:
- Failed CI
  - https://github.com/python/python-docs-zh-tw/actions/runs/9719690366
  - https://github.com/python/python-docs-zh-tw/actions/runs/9620993035
  - https://github.com/python/python-docs-zh-tw/actions/runs/9523580678
  - https://github.com/python/python-docs-zh-tw/actions/runs/9424313958
- After Upgrade
  - https://github.com/rockleona/python-docs-zh-tw/actions/runs/9771150430