### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
As a follow-up of #917, are you in favor of adding `dependabot.yml` in order to get updates for the GitHub actions used by the workflows?