### PR TITLE
ci: use ubuntu 22.04 instead and handle params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -13,4 +13,4 @@ jobs:
         run: sudo apt-get install gettext
 
       - name: Validate
-        run: VERSION=${{ github.event.repository.default_branch }} MODE=dummy make all
+        run: VERSION=${{ github.event.repository.default_branch }} JOBS=4 MODE=html make all

--- a/.github/workflows/deploy-gh-page.yml
+++ b/.github/workflows/deploy-gh-page.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt-get install gettext
 
       - name: Build
-        run: make all
+        run: JOBS=4 MODE=html make all
 
       - name: Deploy to gh page
         uses: JamesIves/github-pages-deploy-action@v4.6.4

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ SPHINX_CONF := $(CPYTHON_CLONE)/Doc/conf.py
 LANGUAGE := zh_TW
 LC_MESSAGES := $(CPYTHON_CLONE)/Doc/locales/$(LANGUAGE)/LC_MESSAGES
 VENV := ~/.venvs/python-docs-i18n/
-MODE := autobuild-dev-html
-JOBS := 4
+MODE := $(or $(MODE), autobuild-dev-html)
+JOBS := $(or $(JOBS), auto)
 
 .PHONY: all
 all: prepare_deps ## Automatically build an html local version


### PR DESCRIPTION
resolve #988, use ubuntu version 22.04 as suggested in https://github.com/python/docsbuild-scripts/issues/186