### PR TITLE
fix: remove the translation since it caused the page to miss some text

### DIFF
--- a/library/time.po
+++ b/library/time.po
@@ -275,7 +275,7 @@ msgstr ""
 #: ../../library/time.rst:953 ../../library/time.rst:962
 #: ../../library/time.rst:975
 msgid "Availability"
-msgstr ":ref:`適用 <availability>`"
+msgstr ""
 
 #: ../../library/time.rst:151
 msgid ""


### PR DESCRIPTION
通靈失敗，見下圖，後面的文字不見了，所以先把翻譯拿掉，之後再來找規則看這邊要怎麼搞
![image](https://github.com/user-attachments/assets/3ee43aab-f73e-4447-a030-0fd1d0b40c1c)
![image](https://github.com/user-attachments/assets/e3f9c46b-a901-4abb-af55-21a60703ea3f)
