### PR TITLE
feat: Add aider translation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.aider*

--- a/.scripts/intercept.py
+++ b/.scripts/intercept.py
@@ -1,0 +1,42 @@
+# /// script
+# dependencies = [
+#     "polib",
+# ]
+# ///
+import argparse
+from pathlib import Path
+
+import polib
+
+
+def get_pofile_from_path(path: Path) -> polib.POFile:
+    if not path.exists():
+        raise ValueError(f"The path '{path.absolute()}' does not exist!")
+
+    if not (path.is_file() and path.suffix == ".po"):
+        raise ValueError(f"{path} doesn't seem to be a .po file")
+
+    try:
+        pofile = polib.pofile(path)
+    except OSError:
+        raise ValueError(f"{path} doesn't seem to be a .po file")
+    return pofile
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "path",
+        help="the path of a PO file",
+    )
+    parser.add_argument("-n", '--occurrence_number', type=int, default=1)
+    args = parser.parse_args()
+    path = Path(args.path).resolve()
+    pofile = get_pofile_from_path(path)
+    occurrence_number = args.occurrence_number
+
+    for entry in pofile:
+        if not any(path.stem in p and int(n) == occurrence_number for p, n in entry.occurrences):
+            continue
+        print(entry.msgid)
+        break

--- a/.scripts/intercept.py
+++ b/.scripts/intercept.py
@@ -25,13 +25,12 @@ def get_pofile_from_path(path: Path) -> polib.POFile:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "path",
-        help="the path of a PO file",
-    )
-    parser.add_argument("-n", '--occurrence_number', type=int, default=1)
+    parser.add_argument("path", type=Path,
+                        help="the path of a PO file")
+    parser.add_argument("-n", '--occurrence_number',
+                        type=int, default=1)
     args = parser.parse_args()
-    path = Path(args.path).resolve()
+    path = args.path.resolve()
     pofile = get_pofile_from_path(path)
     occurrence_number = args.occurrence_number
 

--- a/.scripts/intercept.py
+++ b/.scripts/intercept.py
@@ -1,8 +1,17 @@
-# /// script
-# dependencies = [
-#     "polib",
-# ]
-# ///
+"""
+A utility script to extract message IDs from PO files.
+
+This script extracts a specific message ID from a PO file based on the file name
+and occurrence number. It's useful for retrieving translation strings for
+specific occurrences in the Python documentation.
+
+Usage:
+    python intercept.py path/to/file.po [-n OCCURRENCE_NUMBER]
+
+Arguments:
+    path: Path to a PO file
+    -n, --occurrence_number: The occurrence number to match (default: 1)
+"""
 import argparse
 from pathlib import Path
 
@@ -24,11 +33,13 @@ def get_pofile_from_path(path: Path) -> polib.POFile:
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Extract message IDs from PO files"
+    )
     parser.add_argument("path", type=Path,
                         help="the path of a PO file")
     parser.add_argument("-n", '--occurrence_number',
-                        type=int, default=1)
+                        type=int, default=1, help="the occurrence number to match")
     args = parser.parse_args()
     path = args.path.resolve()
     pofile = get_pofile_from_path(path)

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ $(VENV)/bin/sphinx-lint: $(VENV)/bin/activate
 $(VENV)/bin/blurb: $(VENV)/bin/activate
 	. $(VENV)/bin/activate; python3 -m pip install blurb
 
+$(VENV)/bin/aider: $(VENV)/bin/activate
+	. $(VENV)/bin/activate; python3 -m pip install aider-chat
+
 
 .PHONY: upgrade_venv
 upgrade_venv: $(VENV)/bin/activate ## Upgrade the venv that compiles the doc
@@ -155,6 +158,16 @@ rm_cpython: ## Remove cloned cpython repo
 .PHONY: lint
 lint:  $(VENV)/bin/sphinx-lint  ## Run sphinx-lint
 	$(VENV)/bin/sphinx-lint --enable default-role
+
+.PHONY: translate
+translate:  $(VENV)/bin/aider  ## Run translation with aider. Usage: make translate FILE=path/to/file.po LINE=number
+	@if [ -z "$(FILE)" ] || [ -z "$(LINE)" ]; then \
+		echo "\x1B[1;31mError: Both FILE and LINE arguments are required.\x1B[0m"; \
+		echo "Usage: make translate FILE=path/to/file.po LINE=number"; \
+		exit 1; \
+	fi
+	$(eval MESSAGE=$(shell python3 .scripts/intercept.py $(FILE) -n $(LINE)))
+	aider --no-auto-commits --message 'Translate the following Python documentation into Tranditional Chinese for $(FILE):$(LINE) with message $(MESSAGE). Ensure that the translation is accurate and uses appropriate technical terminology. The output must be in Traditional Chinese. Pay careful attention to context, idiomatic expressions, and any specialized vocabulary related to Python programming. Maintain the structure and format of the original documentation as much as possible to ensure clarity and usability for readers.' $(FILE)
 
 # This allows us to accept extra arguments (by doing nothing when we get a job that doesn't match, rather than throwing an error)
 %:


### PR DESCRIPTION
This pull request introduces a new script for handling `.po` files and updates the `Makefile` to include a new translation target using the `aider-chat` tool. The most important changes are detailed below:

### New Script for `.po` File Handling:

* [`.scripts/intercept.py`](diffhunk://#diff-36453b04d64046d96ec5c75e94ce63dfc1bcdbfd045e20339b899013e0f6597bR1-R42): Added a new script to handle `.po` files, which includes functionality to parse the file and retrieve specific entries based on their occurrences.

### Makefile Enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R103-R105): Added a new target to install the `aider-chat` tool in the virtual environment.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R162-R171): Introduced a new `translate` target that uses the `aider-chat` tool to translate Python documentation into Traditional Chinese. This target requires `FILE` and `LINE` arguments to specify the `.po` file and the line number to translate.

Example
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/c17afa3f-d789-4665-be4d-be5a7e020983" />
