### PR TITLE
chore: Replace python3 -m venv and pip with uv for virtual environment management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,8 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get install gettext
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Validate
         run: VERSION=${{ github.event.repository.default_branch }} JOBS=4 MODE=html make all

--- a/Makefile
+++ b/Makefile
@@ -89,21 +89,21 @@ prepare_cpython:  ## Prepare CPython clone at `../cpython/`.
 
 
 $(VENV)/bin/activate:
-	python3 -m venv $(VENV)
+	uv venv $(VENV)
 
 $(VENV)/bin/sphinx-build: $(VENV)/bin/activate
-	. $(VENV)/bin/activate; python3 -m pip install sphinx python-docs-theme
+	. $(VENV)/bin/activate; uv pip install sphinx python-docs-theme
 
 $(VENV)/bin/sphinx-lint: $(VENV)/bin/activate
-	. $(VENV)/bin/activate; python3 -m pip install sphinx-lint
+	. $(VENV)/bin/activate; uv pip install sphinx-lint
 
 $(VENV)/bin/blurb: $(VENV)/bin/activate
-	. $(VENV)/bin/activate; python3 -m pip install blurb
+	. $(VENV)/bin/activate; uv pip install blurb
 
 
 .PHONY: upgrade_venv
 upgrade_venv: $(VENV)/bin/activate ## Upgrade the venv that compiles the doc
-	@. $(VENV)/bin/activate; python3 -m pip install -q --upgrade sphinx python-docs-theme blurb sphinx-lint
+	@. $(VENV)/bin/activate; uv pip install -q --upgrade sphinx python-docs-theme blurb sphinx-lint
 
 
 .PHONY: progress

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ the PSF for inclusion in the documentation.
 - `安裝好 git <https://help.github.com/articles/set-up-git/>`_\ （Windows
   上請參考 https://gitforwindows.org/）
 - 一個 ``.po`` 檔的編輯器。推薦使用 `Poedit <https://poedit.net>`_，若熟悉 po 檔用一般文字編輯器亦可。
+- 參考 `uv Installation <https://docs.astral.sh/uv/getting-started/installation/>`_ 安裝 uv，以便在本機端預覽翻譯成果。
 - macOS 的使用者還需要先利用 `homebrew <https://brew.sh/index_zh-tw>`_ 安裝 gettext，屆時 Sphinx 會使用到。
 
   .. code-block:: bash


### PR DESCRIPTION
This pull request includes updates to the `Makefile` and `README.rst` to switch from using Python's `venv` and `pip` commands to the `uv` tool for virtual environment and package management.

Changes to `Makefile`:

* Replaced `python3 -m venv` with `uv venv` for creating virtual environments.
* Replaced `python3 -m pip install` with `uv pip install` for installing packages like `sphinx`, `python-docs-theme`, `sphinx-lint`, and `blurb`.
* Updated the `upgrade_venv` target to use `uv pip install -q --upgrade` for upgrading packages.

Changes to `README.rst`:

* Added a reference to `uv Installation` for installing `uv` to preview translation results locally.