### PR TITLE
Translate `library/asyncio.po`

### DIFF
--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -18,6 +18,7 @@ Steven Hsu (StevenHsuYL)
 Taihsiang Ho (tai271828)
 Tsai, Chia-Wen
 Wei-Hsiang (Matt) Wang
+Weilin Du (LamentXU)
 Wilson Wang (Josix)
 Yu Chun Yang
 Jason (chairco)

--- a/library/asyncio.po
+++ b/library/asyncio.po
@@ -194,19 +194,19 @@ msgstr ""
 msgid ""
 "Raises an :ref:`auditing event <auditing>` ``cpython.run_stdin`` with no "
 "arguments."
-msgstr "產生一個 :ref:`審計事件 <auditing>` `cpython.run_stdin`` 且沒有參數。"
+msgstr "產生一個 :ref:`審計事件 <auditing>` `cpython.run_stdin`` 且沒有引數。"
 
 #: ../../library/asyncio.rst:79
 msgid "(also 3.11.10, 3.10.15, 3.9.20, and 3.8.20) Emits audit events."
-msgstr "(也包括 3.11.10、3.10.15、3.9.20 及 3.8.20）發出審計事件。"
+msgstr "(也包括 3.11.10、3.10.15、3.9.20 及 3.8.20）發出稽核事件。"
 
 #: ../../library/asyncio.rst:82
 msgid ""
 "Uses PyREPL if possible, in which case :envvar:`PYTHONSTARTUP` is also "
 "executed. Emits audit events."
 msgstr ""
-"可能的話使用 PyREPL，在這種情況下 :envvar:`PYTHONSTARTUP` 也會被執行。產生審"
-"計事件。"
+"可能的話使用 PyREPL，在這種情況下 :envvar:`PYTHONSTARTUP` 也會被執行。產生稽核"
+"事件。"
 
 #: ../../library/asyncio.rst:90
 msgid "Reference"

--- a/library/asyncio.po
+++ b/library/asyncio.po
@@ -194,7 +194,7 @@ msgstr ""
 msgid ""
 "Raises an :ref:`auditing event <auditing>` ``cpython.run_stdin`` with no "
 "arguments."
-msgstr "產生一個 :ref:`審計事件 <auditing>` `cpython.run_stdin`` 且沒有引數。"
+msgstr "產生一個 :ref:`稽核事件 <auditing>` `cpython.run_stdin`` 且沒有引數。"
 
 #: ../../library/asyncio.rst:79
 msgid "(also 3.11.10, 3.10.15, 3.9.20, and 3.8.20) Emits audit events."

--- a/library/asyncio.po
+++ b/library/asyncio.po
@@ -5,13 +5,14 @@
 # Adrian Liaw <adrianliaw2000@gmail.com>, 2018
 # Matt Wang <mattwang44@gmail.com>, 2021
 # Leo Wang <ascodeasice@gmail.com>, 2023
+# Weilin Du, 2025
 msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.13\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-10-11 00:13+0000\n"
-"PO-Revision-Date: 2021-11-23 12:40+0800\n"
-"Last-Translator: Matt Wang <mattwang44@gmail.com>\n"
+"PO-Revision-Date: 2025-07-06 17:13+0800\n"
+"Last-Translator: Weilin Du\n"
 "Language-Team: Chinese - TAIWAN (https://github.com/python/python-docs-zh-"
 "tw)\n"
 "Language: zh_TW\n"
@@ -19,7 +20,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.0\n"
 
 #: ../../library/asyncio.rst:91
 msgid "High-level APIs"
@@ -149,7 +149,7 @@ msgstr ""
 
 #: ../../includes/wasm-notavail.rst:3
 msgid "Availability"
-msgstr ""
+msgstr "可用性"
 
 #: ../../includes/wasm-notavail.rst:5
 msgid ""
@@ -194,17 +194,19 @@ msgstr ""
 msgid ""
 "Raises an :ref:`auditing event <auditing>` ``cpython.run_stdin`` with no "
 "arguments."
-msgstr ""
+msgstr "產生一個 :ref:`審計事件 <auditing>` `cpython.run_stdin`` 且沒有參數。"
 
 #: ../../library/asyncio.rst:79
 msgid "(also 3.11.10, 3.10.15, 3.9.20, and 3.8.20) Emits audit events."
-msgstr ""
+msgstr "(也包括 3.11.10、3.10.15、3.9.20 及 3.8.20）發出審計事件。"
 
 #: ../../library/asyncio.rst:82
 msgid ""
 "Uses PyREPL if possible, in which case :envvar:`PYTHONSTARTUP` is also "
 "executed. Emits audit events."
 msgstr ""
+"可能的話使用 PyREPL，在這種情況下 :envvar:`PYTHONSTARTUP` 也會被執行。產生審"
+"計事件。"
 
 #: ../../library/asyncio.rst:90
 msgid "Reference"

--- a/library/asyncio.po
+++ b/library/asyncio.po
@@ -205,7 +205,7 @@ msgid ""
 "Uses PyREPL if possible, in which case :envvar:`PYTHONSTARTUP` is also "
 "executed. Emits audit events."
 msgstr ""
-"可能的話使用 PyREPL，在這種情況下 :envvar:`PYTHONSTARTUP` 也會被執行。產生稽核"
+"可能的話使用 PyREPL，在這種情況下 :envvar:`PYTHONSTARTUP` 也會被執行。發出稽核"
 "事件。"
 
 #: ../../library/asyncio.rst:90


### PR DESCRIPTION
面對audit event的翻譯，并未做相關的規定。我推薦兩個翻譯：

審計事件：參考簡中翻譯。
稽核事件：Google&DeepL翻譯。

從我個人的語言習慣上來看，偏向第一個。