### PR TITLE
fix translation of escape

### DIFF
--- a/.scripts/google_translate/utils.py
+++ b/.scripts/google_translate/utils.py
@@ -46,7 +46,7 @@ MAPPING_ZH_TW_COMMON_TRANSLATION_ERROR = {
     '變量': '變數',  # variable
     '常量': '常數',  # constant
     '添加': '新增',  # add
-    '轉義': '逃脫',  # escape
+    '轉義': '跳脫',  # escape
     '基類': '基底類別',  # base class
 }
 

--- a/.scripts/google_translate/utils.py
+++ b/.scripts/google_translate/utils.py
@@ -46,6 +46,7 @@ MAPPING_ZH_TW_COMMON_TRANSLATION_ERROR = {
     '變量': '變數',  # variable
     '常量': '常數',  # constant
     '添加': '新增',  # add
+    '轉義': '逃脫',  # escape
     '基類': '基底類別',  # base class
 }
 

--- a/faq/design.po
+++ b/faq/design.po
@@ -1274,9 +1274,9 @@ msgid ""
 "pass on the string quote character by escaping it with a backslash.  These "
 "rules work well when r-strings are used for their intended purpose."
 msgstr ""
-"設計出純字串是為了提供有自己反斜線轉義處理的處理器（主要是正規表示式）一個方"
+"設計出純字串是為了提供有自己反斜線逃脫處理的處理器（主要是正規表示式）一個方"
 "便的輸入方式。這種處理器會把未配對的結尾反斜線當成錯誤，所以純字串不允許如"
-"此。相對地，他讓你用一個反斜線轉義引號。這些規則在他們預想的目的上正常地運"
+"此。相對地，他讓你用一個反斜線逃脫引號。這些規則在他們預想的目的上正常地運"
 "作。"
 
 #: ../../faq/design.rst:648

--- a/faq/design.po
+++ b/faq/design.po
@@ -1274,9 +1274,9 @@ msgid ""
 "pass on the string quote character by escaping it with a backslash.  These "
 "rules work well when r-strings are used for their intended purpose."
 msgstr ""
-"設計出純字串是為了提供有自己反斜線逃脫處理的處理器（主要是正規表示式）一個方"
+"設計出純字串是為了提供有自己反斜線跳脫處理的處理器（主要是正規表示式）一個方"
 "便的輸入方式。這種處理器會把未配對的結尾反斜線當成錯誤，所以純字串不允許如"
-"此。相對地，他讓你用一個反斜線逃脫引號。這些規則在他們預想的目的上正常地運"
+"此。相對地，他讓你用一個反斜線跳脫引號。這些規則在他們預想的目的上正常地運"
 "作。"
 
 #: ../../faq/design.rst:648

--- a/faq/programming.po
+++ b/faq/programming.po
@@ -2054,7 +2054,7 @@ msgstr "我可以用奇數個反斜線結束原始字串嗎？"
 msgid ""
 "A raw string ending with an odd number of backslashes will escape the "
 "string's quote::"
-msgstr "以奇數個反斜線結尾的原始字串將逃脫字串的引號： ::"
+msgstr "以奇數個反斜線結尾的原始字串將跳脫字串的引號： ::"
 
 #: ../../faq/programming.rst:1036
 msgid ""
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid ""
 "Another is to concatenate a regular string containing an escaped backslash "
 "to the raw string::"
-msgstr "另一種方法是將包含逃脫反斜線的常規字串連接到原始字串： ::"
+msgstr "另一種方法是將包含跳脫反斜線的常規字串連接到原始字串： ::"
 
 #: ../../faq/programming.rst:1051
 msgid ""
@@ -2124,7 +2124,7 @@ msgid ""
 "value of the raw string::"
 msgstr ""
 "請注意，雖然為了確定原始字串的結束位置而使用反斜線「跳脫」引號，但在解釋原始"
-"字串的值時不會發生逃脫。也就是說，反斜線仍然存在於原始字串的值中： ::"
+"字串的值時不會發生跳脫。也就是說，反斜線仍然存在於原始字串的值中： ::"
 
 #: ../../faq/programming.rst:1064
 msgid ""

--- a/faq/programming.po
+++ b/faq/programming.po
@@ -2054,7 +2054,7 @@ msgstr "我可以用奇數個反斜線結束原始字串嗎？"
 msgid ""
 "A raw string ending with an odd number of backslashes will escape the "
 "string's quote::"
-msgstr "以奇數個反斜線結尾的原始字串將轉義字串的引號： ::"
+msgstr "以奇數個反斜線結尾的原始字串將逃脫字串的引號： ::"
 
 #: ../../faq/programming.rst:1036
 msgid ""
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid ""
 "Another is to concatenate a regular string containing an escaped backslash "
 "to the raw string::"
-msgstr "另一種方法是將包含轉義反斜線的常規字串連接到原始字串： ::"
+msgstr "另一種方法是將包含逃脫反斜線的常規字串連接到原始字串： ::"
 
 #: ../../faq/programming.rst:1051
 msgid ""
@@ -2124,7 +2124,7 @@ msgid ""
 "value of the raw string::"
 msgstr ""
 "請注意，雖然為了確定原始字串的結束位置而使用反斜線「跳脫」引號，但在解釋原始"
-"字串的值時不會發生轉義。也就是說，反斜線仍然存在於原始字串的值中： ::"
+"字串的值時不會發生逃脫。也就是說，反斜線仍然存在於原始字串的值中： ::"
 
 #: ../../faq/programming.rst:1064
 msgid ""

--- a/library/json.po
+++ b/library/json.po
@@ -852,7 +852,7 @@ msgid ""
 "these characters will be output as-is."
 msgstr ""
 "如果 *ensure_ascii* 被設為 true（預設值），則輸出時將確保所有輸入的非 ASCII "
-"字元都會被轉義。若 *ensure_ascii* 為 false，則這些字元將照原樣輸出。"
+"字元都會被逃脫。若 *ensure_ascii* 為 false，則這些字元將照原樣輸出。"
 
 #: ../../library/json.rst:501
 msgid ""
@@ -1076,7 +1076,7 @@ msgid ""
 "resulting strings only contain ASCII characters."
 msgstr ""
 "RFC 准許但並不強制編碼器的 *ensure_ascii=True* 行為是預設值，但本模組依然實作"
-"了此一選項作為預設，因此本模組預設會轉義所有非 ASCII 字元。"
+"了此一選項作為預設，因此本模組預設會逃脫所有非 ASCII 字元。"
 
 #: ../../library/json.rst:641
 msgid ""
@@ -1343,7 +1343,7 @@ msgstr "按照鍵值的字母順序對輸出字典進行排序。"
 msgid ""
 "Disable escaping of non-ascii characters, see :func:`json.dumps` for more "
 "information."
-msgstr "關閉非 ASCII 字元的自動轉義功能。詳情請參照 :func:`json.dumps`。"
+msgstr "關閉非 ASCII 字元的自動逃脫功能。詳情請參照 :func:`json.dumps`。"
 
 #: ../../library/json.rst:809
 msgid "Parse every input line as separate JSON object."

--- a/library/json.po
+++ b/library/json.po
@@ -852,7 +852,7 @@ msgid ""
 "these characters will be output as-is."
 msgstr ""
 "如果 *ensure_ascii* 被設為 true（預設值），則輸出時將確保所有輸入的非 ASCII "
-"字元都會被逃脫。若 *ensure_ascii* 為 false，則這些字元將照原樣輸出。"
+"字元都會被跳脫。若 *ensure_ascii* 為 false，則這些字元將照原樣輸出。"
 
 #: ../../library/json.rst:501
 msgid ""
@@ -1076,7 +1076,7 @@ msgid ""
 "resulting strings only contain ASCII characters."
 msgstr ""
 "RFC 准許但並不強制編碼器的 *ensure_ascii=True* 行為是預設值，但本模組依然實作"
-"了此一選項作為預設，因此本模組預設會逃脫所有非 ASCII 字元。"
+"了此一選項作為預設，因此本模組預設會跳脫所有非 ASCII 字元。"
 
 #: ../../library/json.rst:641
 msgid ""
@@ -1343,7 +1343,7 @@ msgstr "按照鍵值的字母順序對輸出字典進行排序。"
 msgid ""
 "Disable escaping of non-ascii characters, see :func:`json.dumps` for more "
 "information."
-msgstr "關閉非 ASCII 字元的自動逃脫功能。詳情請參照 :func:`json.dumps`。"
+msgstr "關閉非 ASCII 字元的自動跳脫功能。詳情請參照 :func:`json.dumps`。"
 
 #: ../../library/json.rst:809
 msgid "Parse every input line as separate JSON object."

--- a/library/re.po
+++ b/library/re.po
@@ -1485,9 +1485,9 @@ msgid ""
 msgstr ""
 "回傳透過以替換 *repl* 取代 *string* 中最左邊不重疊出現的 *pattern* 所獲得的字"
 "串。如果未找到該模式，則不改變 *string* 並回傳。*repl* 可以是字串或函式；如果"
-"它是字串，則處理其中的任何反斜線轉義。也就是說 ``\\n`` 會被轉換為單一換行符、"
-"``\\r`` 會被轉換為回車符 (carriage return) 等等。ASCII 字母的未知轉義符會被保"
-"留以供將來使用並被視為錯誤。其他未知轉義符例如 ``\\&`` 會被單獨保留。例如 "
+"它是字串，則處理其中的任何反斜線逃脫。也就是說 ``\\n`` 會被轉換為單一換行符、"
+"``\\r`` 會被轉換為回車符 (carriage return) 等等。ASCII 字母的未知逃脫符會被保"
+"留以供將來使用並被視為錯誤。其他未知逃脫符例如 ``\\&`` 會被單獨保留。例如 "
 "``\\6`` 的反向參照將被替換為模式中第 6 組匹配的子字串。例如： ::"
 
 #: ../../library/re.rst:1073
@@ -1565,7 +1565,7 @@ msgid ""
 "backreference ``\\g<0>`` substitutes in the entire substring matched by the "
 "RE."
 msgstr ""
-"在字串型別 *repl* 引數中，除了上述字元轉義和反向參照之外，``\\g<name>`` 將使"
+"在字串型別 *repl* 引數中，除了上述字元逃脫和反向參照之外，``\\g<name>`` 將使"
 "用名為 ``name`` 的群組所匹配到的子字串，如 ``(?P<name>...)`` 所定義的語法。"
 "``\\g<number>`` 使用對應的群組編號；因此 ``\\g<2>`` 等價於 ``\\2``，但在諸如 "
 "``\\g<2>0`` 之類的替換中並非模糊不清 (isn't ambiguous)。``\\20`` 將被直譯為對"
@@ -1581,14 +1581,14 @@ msgid ""
 "Unknown escapes in *pattern* consisting of ``'\\'`` and an ASCII letter now "
 "are errors."
 msgstr ""
-"在由 ``'\\'`` 和一個 ASCII 字母組成之 *pattern* 中的未知轉義符現在為錯誤。"
+"在由 ``'\\'`` 和一個 ASCII 字母組成之 *pattern* 中的未知逃脫符現在為錯誤。"
 
 #: ../../library/re.rst:1128
 msgid ""
 "Unknown escapes in *repl* consisting of ``'\\'`` and an ASCII letter now are "
 "errors. An empty match can occur immediately after a non-empty match."
 msgstr ""
-"由 ``'\\'`` 和一個 ASCII 字母組成之 *repl* 中的未知轉義符現在為錯誤。"
+"由 ``'\\'`` 和一個 ASCII 字母組成之 *repl* 中的未知逃脫符現在為錯誤。"
 "非空匹配後可以緊接著出現空匹配。"
 
 #: ../../library/re.rst:1133
@@ -1623,7 +1623,7 @@ msgid ""
 "an arbitrary literal string that may have regular expression metacharacters "
 "in it.  For example::"
 msgstr ""
-"對 *pattern* 中的特殊字元進行轉義。如果你想要匹配其中可能包含正規表示式元字"
+"對 *pattern* 中的特殊字元進行逃脫。如果你想要匹配其中可能包含正規表示式元字"
 "元 (metacharacter) 的任意文本字串，這會非常有用。例如： ::"
 
 #: ../../library/re.rst:1160
@@ -1657,7 +1657,7 @@ msgid ""
 "This function must not be used for the replacement string in :func:`sub` "
 "and :func:`subn`, only backslashes should be escaped.  For example::"
 msgstr ""
-"此函式不得用於 :func:`sub` 和 :func:`subn` 中的替換字串，僅應轉義反斜線。例"
+"此函式不得用於 :func:`sub` 和 :func:`subn` 中的替換字串，僅應逃脫反斜線。例"
 "如： ::"
 
 #: ../../library/re.rst:1174
@@ -1674,7 +1674,7 @@ msgstr ""
 
 #: ../../library/re.rst:1179
 msgid "The ``'_'`` character is no longer escaped."
-msgstr "``'_'`` 字元不再被轉義。"
+msgstr "``'_'`` 字元不再被逃脫。"
 
 #: ../../library/re.rst:1182
 msgid ""

--- a/library/re.po
+++ b/library/re.po
@@ -1485,9 +1485,9 @@ msgid ""
 msgstr ""
 "回傳透過以替換 *repl* 取代 *string* 中最左邊不重疊出現的 *pattern* 所獲得的字"
 "串。如果未找到該模式，則不改變 *string* 並回傳。*repl* 可以是字串或函式；如果"
-"它是字串，則處理其中的任何反斜線逃脫。也就是說 ``\\n`` 會被轉換為單一換行符、"
-"``\\r`` 會被轉換為回車符 (carriage return) 等等。ASCII 字母的未知逃脫符會被保"
-"留以供將來使用並被視為錯誤。其他未知逃脫符例如 ``\\&`` 會被單獨保留。例如 "
+"它是字串，則處理其中的任何反斜線跳脫。也就是說 ``\\n`` 會被轉換為單一換行符、"
+"``\\r`` 會被轉換為回車符 (carriage return) 等等。ASCII 字母的未知跳脫符會被保"
+"留以供將來使用並被視為錯誤。其他未知跳脫符例如 ``\\&`` 會被單獨保留。例如 "
 "``\\6`` 的反向參照將被替換為模式中第 6 組匹配的子字串。例如： ::"
 
 #: ../../library/re.rst:1073
@@ -1565,7 +1565,7 @@ msgid ""
 "backreference ``\\g<0>`` substitutes in the entire substring matched by the "
 "RE."
 msgstr ""
-"在字串型別 *repl* 引數中，除了上述字元逃脫和反向參照之外，``\\g<name>`` 將使"
+"在字串型別 *repl* 引數中，除了上述字元跳脫和反向參照之外，``\\g<name>`` 將使"
 "用名為 ``name`` 的群組所匹配到的子字串，如 ``(?P<name>...)`` 所定義的語法。"
 "``\\g<number>`` 使用對應的群組編號；因此 ``\\g<2>`` 等價於 ``\\2``，但在諸如 "
 "``\\g<2>0`` 之類的替換中並非模糊不清 (isn't ambiguous)。``\\20`` 將被直譯為對"
@@ -1581,14 +1581,14 @@ msgid ""
 "Unknown escapes in *pattern* consisting of ``'\\'`` and an ASCII letter now "
 "are errors."
 msgstr ""
-"在由 ``'\\'`` 和一個 ASCII 字母組成之 *pattern* 中的未知逃脫符現在為錯誤。"
+"在由 ``'\\'`` 和一個 ASCII 字母組成之 *pattern* 中的未知跳脫符現在為錯誤。"
 
 #: ../../library/re.rst:1128
 msgid ""
 "Unknown escapes in *repl* consisting of ``'\\'`` and an ASCII letter now are "
 "errors. An empty match can occur immediately after a non-empty match."
 msgstr ""
-"由 ``'\\'`` 和一個 ASCII 字母組成之 *repl* 中的未知逃脫符現在為錯誤。"
+"由 ``'\\'`` 和一個 ASCII 字母組成之 *repl* 中的未知跳脫符現在為錯誤。"
 "非空匹配後可以緊接著出現空匹配。"
 
 #: ../../library/re.rst:1133
@@ -1623,7 +1623,7 @@ msgid ""
 "an arbitrary literal string that may have regular expression metacharacters "
 "in it.  For example::"
 msgstr ""
-"對 *pattern* 中的特殊字元進行逃脫。如果你想要匹配其中可能包含正規表示式元字"
+"對 *pattern* 中的特殊字元進行跳脫。如果你想要匹配其中可能包含正規表示式元字"
 "元 (metacharacter) 的任意文本字串，這會非常有用。例如： ::"
 
 #: ../../library/re.rst:1160
@@ -1657,7 +1657,7 @@ msgid ""
 "This function must not be used for the replacement string in :func:`sub` "
 "and :func:`subn`, only backslashes should be escaped.  For example::"
 msgstr ""
-"此函式不得用於 :func:`sub` 和 :func:`subn` 中的替換字串，僅應逃脫反斜線。例"
+"此函式不得用於 :func:`sub` 和 :func:`subn` 中的替換字串，僅應跳脫反斜線。例"
 "如： ::"
 
 #: ../../library/re.rst:1174
@@ -1674,7 +1674,7 @@ msgstr ""
 
 #: ../../library/re.rst:1179
 msgid "The ``'_'`` character is no longer escaped."
-msgstr "``'_'`` 字元不再被逃脫。"
+msgstr "``'_'`` 字元不再被跳脫。"
 
 #: ../../library/re.rst:1182
 msgid ""


### PR DESCRIPTION
escape 在繁體中文應該是「跳脫」比較常用，但[現有翻譯還是出現蠻多「轉義」的](https://github.com/search?q=repo%3Apython%2Fpython-docs-zh-tw%20%E8%BD%89%E7%BE%A9&type=code)，我再找時間改掉
https://w.wiki/EhLU
<img width="420" height="133" alt="image" src="https://github.com/user-attachments/assets/51dcb45e-24f8-4b4a-b9aa-509462cfe2c3" />

_Originally posted by @mattwang44 in https://github.com/python/python-docs-zh-tw/pull/1097#discussion_r2200018241_
 
這個PR修復了所有這種情況。將escape的翻譯統一爲“逃脫”