### PR TITLE
Translate fuzzy entries from upstream sync

### DIFF
--- a/c-api/typehints.po
+++ b/c-api/typehints.po
@@ -62,7 +62,6 @@ msgid "Here's an example of how to make an extension type generic::"
 msgstr "以下是個讓一個擴充型別泛用化 (generic) 的例子： ::"
 
 #: ../../c-api/typehints.rst:30
-#, fuzzy
 msgid ""
 "...\n"
 "static PyMethodDef my_obj_methods[] = {\n"
@@ -77,8 +76,8 @@ msgstr ""
 "static PyMethodDef my_obj_methods[] = {\n"
 "    // 其他方法。\n"
 "    ...\n"
-"    {\"__class_getitem__\", Py_GenericAlias, METH_O|METH_CLASS, \"See PEP "
-"585\"}\n"
+"    {\"__class_getitem__\", Py_GenericAlias, METH_O|METH_CLASS, \"my_obj is "
+"generic over its contained type\"}\n"
 "    ...\n"
 "}"
 

--- a/library/constants.po
+++ b/library/constants.po
@@ -45,20 +45,17 @@ msgstr ""
 "出 :exc:`SyntaxError`。"
 
 #: ../../library/constants.rst:22
-#, fuzzy
 msgid ""
 "An object frequently used to represent the absence of a value, as when "
 "default arguments are not passed to a function. Assignments to ``None`` are "
 "illegal and raise a :exc:`SyntaxError`. ``None`` is the sole instance of "
 "the :class:`~types.NoneType` type."
 msgstr ""
-"型別 ``NoneType`` 的唯一值。``None`` 經常被使用來表達缺少值，例如未傳送預設的"
-"引數至函式時，相對應參數即會被賦予 ``None``。對於 ``None`` 的賦值是不合法的，"
-"並且會拋出 :exc:`SyntaxError`。``None`` 是型別 :data:`~types.NoneType` 的唯一"
-"實例。"
+"一個經常被使用來表達缺少值的物件，例如未傳送預設的引數至函式時。對於 "
+"``None`` 的賦值是不合法的，並且會引發 :exc:`SyntaxError`。``None`` 是 :class:"
+"`~types.NoneType` 型別的唯一實例。"
 
 #: ../../library/constants.rst:30
-#, fuzzy
 msgid ""
 "A special value which should be returned by the binary special methods (e."
 "g. :meth:`~object.__eq__`, :meth:`~object.__lt__`, :meth:`~object.__add__`, :"
@@ -74,7 +71,7 @@ msgstr ""
 "傳的特殊值，代表著該運算沒有針對其他型別的實作。同理也可以被原地二元特殊方法 "
 "(in-place binary special methods) （如：:meth:`~object.__imul__`、:meth:"
 "`~object.__iand__` 等）回傳。它不應該被作為 boolean（布林）來解讀。:data:`!"
-"NotImplemented` 是型別 :data:`types.NotImplementedType` 的唯一實例。"
+"NotImplemented` 是 :class:`types.NotImplementedType` 型別的唯一實例。"
 
 #: ../../library/constants.rst:40
 msgid ""
@@ -122,7 +119,6 @@ msgstr ""
 "`DeprecationWarning`"
 
 #: ../../library/constants.rst:68
-#, fuzzy
 msgid ""
 "The same as the ellipsis literal \"``...``\", an object frequently used to "
 "indicate that something is omitted. Assignment to ``Ellipsis`` is possible, "
@@ -131,7 +127,7 @@ msgid ""
 msgstr ""
 "與刪節號 \"``...``\" 字面相同，是一個經常被用來表示某些東西被省略的物件。對"
 "於 ``Ellipsis`` 的賦值是可能的，但對於 ``...`` 的賦值會引發 :exc:"
-"`SyntaxError`。``Ellipsis`` 是型別 :data:`types.EllipsisType` 的唯一實例。"
+"`SyntaxError`。``Ellipsis`` 是 :class:`types.EllipsisType` 型別的唯一實例。"
 
 #: ../../library/constants.rst:76
 msgid ""

--- a/library/io.po
+++ b/library/io.po
@@ -884,26 +884,23 @@ msgid ""
 msgstr ":class:`RawIOBase` 除了 :class:`IOBase` 的方法外，還提供以下這些方法："
 
 #: ../../library/io.rst:496
-#, fuzzy
 msgid ""
 "Read up to *size* bytes from the object and return them.  As a convenience, "
 "if *size* is unspecified or -1, all bytes until EOF are returned."
 msgstr ""
 "從物件中讀取最多 *size* 個位元組並回傳。方便起見，如果 *size* 未指定或為 -1，"
-"則回傳直到檔案結尾 (EOF) 的所有位元組。否則，只會進行一次系統呼叫。如果作業系"
-"統呼叫回傳的位元組少於 *size*，則可能回傳少於 *size* 的位元組。"
+"則回傳直到檔案結尾 (EOF) 的所有位元組。"
 
 #: ../../library/io.rst:499
-#, fuzzy
 msgid ""
 "Attempts to make only one system call but will retry if interrupted and the "
 "signal handler does not raise an exception (see :pep:`475` for the "
 "rationale). This means fewer than *size* bytes may be returned if the "
 "operating system call returns fewer than *size* bytes."
 msgstr ""
-"從物件中讀取最多 *size* 個位元組並回傳。方便起見，如果 *size* 未指定或為 -1，"
-"則回傳直到檔案結尾 (EOF) 的所有位元組。否則，只會進行一次系統呼叫。如果作業系"
-"統呼叫回傳的位元組少於 *size*，則可能回傳少於 *size* 的位元組。"
+"嘗試只進行一次系統呼叫，但若被中斷且訊號處理器未引發例外，則會重試（請參閱 :"
+"pep:`475` 的原因說明）。這意味著如果作業系統呼叫回傳的位元組少於 *size*，則可"
+"能回傳少於 *size* 的位元組。"
 
 #: ../../library/io.rst:504
 msgid ""
@@ -926,17 +923,15 @@ msgid ""
 msgstr "讀取並回傳串流中直到檔案結尾的所有位元組，必要時使用多次對串流的呼叫。"
 
 #: ../../library/io.rst:516
-#, fuzzy
 msgid ""
 "If ``0`` bytes are returned this indicates end of file. If the object is in "
 "non-blocking mode and the underlying :meth:`read` returns ``None`` "
 "indicating no bytes are available, ``None`` is returned."
 msgstr ""
-"如果回傳了 0 位元組，且 *size* 不是 0，這表示檔案結尾 (end of file)。如果物件"
-"處於非阻塞模式且沒有可用的位元組，則回傳 ``None``。"
+"如果回傳了 ``0`` 個位元組，這表示檔案結尾 (end of file)。如果物件處於非阻塞模"
+"式且底層的 :meth:`read` 回傳 ``None`` 表示沒有可用的位元組，則回傳 ``None``。"
 
 #: ../../library/io.rst:522
-#, fuzzy
 msgid ""
 "Read bytes into a pre-allocated, writable :term:`bytes-like object` *b*, and "
 "return the number of bytes read.  For example, *b* might be a :class:"
@@ -946,14 +941,13 @@ msgstr ""
 "讀取的位元組數量。例如，*b* 可能是一個 :class:`bytearray`。"
 
 #: ../../library/io.rst:526
-#, fuzzy
 msgid ""
 "If ``0`` is returned and ``len(b)`` is not ``0``, this indicates end of "
 "file. If the object is in non-blocking mode and no bytes are available, "
 "``None`` is returned."
 msgstr ""
-"如果回傳了 0 位元組，且 *size* 不是 0，這表示檔案結尾 (end of file)。如果物件"
-"處於非阻塞模式且沒有可用的位元組，則回傳 ``None``。"
+"如果回傳了 ``0`` 且 ``len(b)`` 不是 ``0``，這表示檔案結尾 (end of file)。如果"
+"物件處於非阻塞模式且沒有可用的位元組，則回傳 ``None``。"
 
 #: ../../library/io.rst:532
 msgid ""

--- a/library/math.po
+++ b/library/math.po
@@ -878,7 +878,6 @@ msgstr ""
 "``copysign(1.0, -0.0)`` 回傳 *-1.0*。"
 
 #: ../../library/math.rst:324
-#, fuzzy
 msgid ""
 "Return the mantissa and exponent of *x* as the pair ``(m, e)``. If *x* is a "
 "finite nonzero number, then *m* is a float with ``0.5 <= abs(m) < 1.0`` and "
@@ -886,9 +885,10 @@ msgid ""
 "0)``. This is used to \"pick apart\" the internal representation of a float "
 "in a portable way."
 msgstr ""
-"以 ``(m, e)`` 對的格式回傳 *x* 的尾數 *m* 及指數 *e*。*m* 是浮點數而 *e* 是整"
-"數，且兩者精確地使 ``x == m * 2**e``。若 *x* 為零，回傳 ``(0.0, 0)``，否則令 "
-"``0.5 <= abs(m) < 1``。此函式用於以可攜的方式「分割」浮點數內部表示法。"
+"以 ``(m, e)`` 對的格式回傳 *x* 的尾數 *m* 及指數 *e*。若 *x* 是有限的非零數，"
+"則 *m* 是一個浮點數且 ``0.5 <= abs(m) < 1.0``，整數 *e* 使得 ``x == m * "
+"2**e`` 完全成立。否則，回傳 ``(x, 0)``。此函式用於以可攜的方式「分割」浮點數"
+"內部表示法。"
 
 #: ../../library/math.rst:331
 msgid ""

--- a/library/ssl.po
+++ b/library/ssl.po
@@ -255,9 +255,12 @@ msgstr ""
 "`SSLContext.load_verify_locations` 一樣。如果三個值都是 :const:`None`，此函式"
 "會自動選擇系統預設的 CA 憑證。"
 
-# Skylull: `high encryption cipher` 可能是指 https://superuser.com/questions/1751902/how-to-check-which-ciphers-are-included-in-high-ciphers-constant
+# Skylull: `high encryption cipher` 可能是指
+# https://superuser.com/questions/1751902/how-to-check-which-ciphers-are-
+# included-in-high-ciphers-constant
 # 其文中表示可能是指 128bit 以上 key length 的加密算法，需要其他來源佐證。
-# 或是 https://help.fortinet.com/fweb/582/Content/FortiWeb/fortiweb-admin/supported_cipher_suites.htm#ssl_414712646_1189301
+# 或是 https://help.fortinet.com/fweb/582/Content/FortiWeb/fortiweb-
+# admin/supported_cipher_suites.htm#ssl_414712646_1189301
 #: ../../library/ssl.rst:143
 msgid ""
 "The settings are: :data:`PROTOCOL_TLS_CLIENT` or :data:"
@@ -1530,14 +1533,13 @@ msgstr ""
 "wrap_socket` 來包裝 socket。"
 
 #: ../../library/ssl.rst:1100
-#, fuzzy
 msgid ""
 ":class:`SSLSocket` instances must be created with :meth:`~SSLContext."
 "wrap_socket`. In earlier versions, it was possible to create instances "
 "directly. This was never documented or officially supported."
 msgstr ""
 ":class:`SSLSocket` 實例必須使用 :meth:`~SSLContext.wrap_socket` 建立。在較早"
-"的版本中可以直接建立實例，但這從未被記錄或正式支援。"
+"的版本中，可以直接建立實例。這從未被記錄或正式支援。"
 
 #: ../../library/ssl.rst:1106
 msgid ""
@@ -3933,14 +3935,13 @@ msgid ""
 msgstr ""
 
 #: ../../library/ssl.rst:2755
-#, fuzzy
 msgid ""
 ">>> client_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
 ">>> client_context.minimum_version = ssl.TLSVersion.TLSv1_2\n"
 ">>> client_context.maximum_version = ssl.TLSVersion.TLSv1_3"
 msgstr ""
 ">>> client_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
-">>> client_context.minimum_version = ssl.TLSVersion.TLSv1_3\n"
+">>> client_context.minimum_version = ssl.TLSVersion.TLSv1_2\n"
 ">>> client_context.maximum_version = ssl.TLSVersion.TLSv1_3"
 
 #: ../../library/ssl.rst:2760

--- a/library/stdtypes.po
+++ b/library/stdtypes.po
@@ -4166,9 +4166,8 @@ msgstr ""
 "['foo   ']"
 
 #: ../../library/stdtypes.rst:2660
-#, fuzzy
 msgid "See also :meth:`join` and :meth:`rsplit`."
-msgstr "另請參閱 :meth:`find` 和 :meth:`rindex`。"
+msgstr "另請參閱 :meth:`join` 和 :meth:`rsplit`。"
 
 #: ../../library/stdtypes.rst:2668
 msgid ""

--- a/library/typing.po
+++ b/library/typing.po
@@ -1302,14 +1302,13 @@ msgid "The :data:`Any` type"
 msgstr ":data:`Any` 型別"
 
 #: ../../library/typing.rst:721
-#, fuzzy
 msgid ""
 "A special kind of type is :data:`Any`. A static type checker will treat "
 "every type as assignable to :data:`Any` and :data:`Any` as assignable to "
 "every type."
 msgstr ""
-":data:`Any` 是一種特別的型別。一個靜態型別檢查器會將每個型別視為可相容於 :"
-"data:`Any` 且 :data:`Any` 也可以相容於每個型別。"
+":data:`Any` 是一種特別的型別。靜態型別檢查器會將每個型別視為可賦值給 :data:"
+"`Any`，且 :data:`Any` 也可賦值給每個型別。"
 
 #: ../../library/typing.rst:725
 msgid ""
@@ -1542,14 +1541,12 @@ msgid "Special type indicating an unconstrained type."
 msgstr "特別型別，指出一個不受約束 (unconstrained) 的型別。"
 
 #: ../../library/typing.rst:854
-#, fuzzy
 msgid "Every type is assignable to :data:`Any`."
-msgstr "所有型別皆與 :data:`Any` 相容。"
+msgstr "所有型別皆可賦值給 :data:`Any`。"
 
 #: ../../library/typing.rst:855
-#, fuzzy
 msgid ":data:`Any` is assignable to every type."
-msgstr ":data:`Any` 相容於所有型別。"
+msgstr ":data:`Any` 可賦值給所有型別。"
 
 #: ../../library/typing.rst:857
 msgid ""
@@ -2292,17 +2289,16 @@ msgid ":data:`ClassVar` accepts only types and cannot be further subscribed."
 msgstr ":data:`ClassVar` 只接受型別請不得使用下標。"
 
 #: ../../library/typing.rst:1295
-#, fuzzy
 msgid ""
 ":data:`ClassVar` is not a class itself, and cannot be used with :func:"
 "`isinstance` or :func:`issubclass`. :data:`ClassVar` does not change Python "
 "runtime behavior, but it can be used by static type checkers. For example, a "
 "type checker might flag the following code as an error::"
 msgstr ""
-":data:`ClassVar` 並不代表該類別本身，而且不應該和 :func:`isinstance` 或是 :"
+":data:`ClassVar` 並不代表該類別本身，而且不能和 :func:`isinstance` 或是 :"
 "func:`issubclass` 一起使用。:data:`ClassVar` 不會改變 Python runtime 的行為，"
-"但它可以被第三方的型別檢查器使用。舉例來說，一個型別檢查器可能會標記下方的程"
-"式碼為一個錯誤： ::"
+"但它可以被靜態型別檢查器使用。舉例來說，一個型別檢查器可能會標記下方的程式碼"
+"為一個錯誤： ::"
 
 #: ../../library/typing.rst:1301
 msgid ""
@@ -2379,7 +2375,6 @@ msgid ""
 msgstr "特殊型別建構，用來標記一個 :class:`TypedDict` 的項目是唯讀的。"
 
 #: ../../library/typing.rst:1362
-#, fuzzy
 msgid ""
 "class Movie(TypedDict):\n"
 "   title: ReadOnly[str]\n"
@@ -2395,7 +2390,7 @@ msgstr ""
 "\n"
 "def mutate_movie(m: Movie) -> None:\n"
 "   m[\"year\"] = 1999  # allowed\n"
-"   m[\"title\"] = \"The Matrix\"  # 型別檢查器錯誤"
+"   m[\"title\"] = \"The Matrix\"  # type checker error"
 
 #: ../../library/typing.rst:1370
 msgid "There is no runtime checking for this property."
@@ -4623,29 +4618,24 @@ msgid ""
 msgstr ""
 
 #: ../../library/typing.rst:2856
-#, fuzzy
 msgid "A protocol with one abstract method ``__bytes__``."
-msgstr "一個有抽象方法 ``__bytes__`` 的 ABC。"
+msgstr "一個有抽象方法 ``__bytes__`` 的協定。"
 
 #: ../../library/typing.rst:2860
-#, fuzzy
 msgid "A protocol with one abstract method ``__complex__``."
-msgstr "一個有抽象方法 ``__complex__`` 的 ABC。"
+msgstr "一個有抽象方法 ``__complex__`` 的協定。"
 
 #: ../../library/typing.rst:2864
-#, fuzzy
 msgid "A protocol with one abstract method ``__float__``."
-msgstr "一個有抽象方法 ``__float__`` 的 ABC。"
+msgstr "一個有抽象方法 ``__float__`` 的協定。"
 
 #: ../../library/typing.rst:2868
-#, fuzzy
 msgid "A protocol with one abstract method ``__index__``."
-msgstr "一個有抽象方法 ``__index__`` 的 ABC。"
+msgstr "一個有抽象方法 ``__index__`` 的協定。"
 
 #: ../../library/typing.rst:2874
-#, fuzzy
 msgid "A protocol with one abstract method ``__int__``."
-msgstr "一個有抽象方法 ``__int__`` 的 ABC。"
+msgstr "一個有抽象方法 ``__int__`` 的協定。"
 
 #: ../../library/typing.rst:2878
 msgid ""

--- a/library/typing.po
+++ b/library/typing.po
@@ -2390,7 +2390,7 @@ msgstr ""
 "\n"
 "def mutate_movie(m: Movie) -> None:\n"
 "   m[\"year\"] = 1999  # allowed\n"
-"   m[\"title\"] = \"The Matrix\"  # type checker error"
+"   m[\"title\"] = \"The Matrix\"  # 型別檢查器錯誤"
 
 #: ../../library/typing.rst:1370
 msgid "There is no runtime checking for this property."

--- a/library/urllib.request.po
+++ b/library/urllib.request.po
@@ -1757,7 +1757,6 @@ msgid "Use the *headers* argument to the :class:`Request` constructor, or::"
 msgstr "使用 :class:`Request` 建構函式的 *headers* 引數，或： ::"
 
 #: ../../library/urllib.request.rst:1370
-#, fuzzy
 msgid ""
 "import urllib.request\n"
 "req = urllib.request.Request('http://www.example.com/')\n"
@@ -1769,7 +1768,7 @@ msgid ""
 msgstr ""
 "import urllib.request\n"
 "req = urllib.request.Request('http://www.example.com/')\n"
-"req.add_header('Referer', 'http://www.python.org/')\n"
+"req.add_header('Referer', 'https://www.python.org/')\n"
 "# 自訂預設的使用者代理標頭值：\n"
 "req.add_header('User-Agent', 'urllib-example/0.1 (Contact: . . .)')\n"
 "with urllib.request.urlopen(req) as f:\n"
@@ -1809,7 +1808,6 @@ msgid ""
 msgstr ""
 
 #: ../../library/urllib.request.rst:1398
-#, fuzzy
 msgid ""
 ">>> import urllib.request\n"
 ">>> import urllib.parse\n"
@@ -1822,7 +1820,7 @@ msgstr ""
 ">>> import urllib.request\n"
 ">>> import urllib.parse\n"
 ">>> params = urllib.parse.urlencode({'spam': 1, 'eggs': 2, 'bacon': 0})\n"
-">>> url = \"http://www.musi-cal.com/cgi-bin/query?%s\" % params\n"
+">>> url = \"https://www.python.org/?%s\" % params\n"
 ">>> with urllib.request.urlopen(url) as f:\n"
 "...     print(f.read().decode('utf-8'))\n"
 "..."
@@ -1835,7 +1833,6 @@ msgid ""
 msgstr ""
 
 #: ../../library/urllib.request.rst:1409
-#, fuzzy
 msgid ""
 ">>> import urllib.request\n"
 ">>> import urllib.parse\n"
@@ -1849,8 +1846,7 @@ msgstr ""
 ">>> import urllib.parse\n"
 ">>> data = urllib.parse.urlencode({'spam': 1, 'eggs': 2, 'bacon': 0})\n"
 ">>> data = data.encode('ascii')\n"
-">>> with urllib.request.urlopen(\"http://requestb.in/xrbl82xr\", data) as "
-"f:\n"
+">>> with urllib.request.urlopen(\"https://httpbin.org/post\", data) as f:\n"
 "...     print(f.read().decode('utf-8'))\n"
 "..."
 
@@ -1861,7 +1857,6 @@ msgid ""
 msgstr ""
 
 #: ../../library/urllib.request.rst:1420
-#, fuzzy
 msgid ""
 ">>> import urllib.request\n"
 ">>> proxies = {'http': 'http://proxy.example.com:8080/'}\n"
@@ -1875,7 +1870,7 @@ msgstr ""
 ">>> proxies = {'http': 'http://proxy.example.com:8080/'}\n"
 ">>> opener = urllib.request.build_opener(urllib.request."
 "ProxyHandler(proxies))\n"
-">>> with opener.open(\"http://www.python.org\") as f:\n"
+">>> with opener.open(\"https://www.python.org\") as f:\n"
 "...     f.read().decode('utf-8')\n"
 "..."
 
@@ -1886,7 +1881,6 @@ msgid ""
 msgstr ""
 
 #: ../../library/urllib.request.rst:1429
-#, fuzzy
 msgid ""
 ">>> import urllib.request\n"
 ">>> opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))\n"
@@ -1895,8 +1889,8 @@ msgid ""
 "..."
 msgstr ""
 ">>> import urllib.request\n"
-">>> opener = urllib.request.build_opener(urllib.request.ProxyHandler({}}))\n"
-">>> with opener.open(\"http://www.python.org/\") as f:\n"
+">>> opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))\n"
+">>> with opener.open(\"https://www.python.org/\") as f:\n"
 "...     f.read().decode('utf-8')\n"
 "..."
 
@@ -1938,7 +1932,6 @@ msgid "The following example illustrates the most common usage scenario::"
 msgstr ""
 
 #: ../../library/urllib.request.rst:1463
-#, fuzzy
 msgid ""
 ">>> import urllib.request\n"
 ">>> local_filename, headers = urllib.request.urlretrieve('https://python."
@@ -1947,7 +1940,7 @@ msgid ""
 ">>> html.close()"
 msgstr ""
 ">>> import urllib.request\n"
-">>> local_filename, headers = urllib.request.urlretrieve('http://python."
+">>> local_filename, headers = urllib.request.urlretrieve('https://python."
 "org/')\n"
 ">>> html = open(local_filename)\n"
 ">>> html.close()"

--- a/library/zipfile.po
+++ b/library/zipfile.po
@@ -628,7 +628,6 @@ msgstr ""
 "加密檔案的密碼，為一個 :class:`bytes` 物件。"
 
 #: ../../library/zipfile.rst:416
-#, fuzzy
 msgid ""
 "Never extract archives from untrusted sources without prior inspection. It "
 "is possible that files are created outside of *path*, for example, members "
@@ -636,8 +635,8 @@ msgid ""
 "module attempts to prevent that. See :meth:`extract` note."
 msgstr ""
 "絕不要在未經事先檢查的情況下，從不受信任的來源解壓縮封存檔案。檔案有可能被建"
-"立在 *path* 之外，例如，成員具有以 ``\"/\"`` 開頭的絕對檔名或帶有兩個點 "
-"``\"..\"`` 的檔名。本模組會試圖防止這種情況。請參閱 :meth:`extract` 的註解。"
+"立在 *path* 之外，例如，成員具有絕對檔名或帶有 \"..\" 元件的檔名。本模組會試"
+"圖防止這種情況。請參閱 :meth:`extract` 的註解。"
 
 #: ../../library/zipfile.rst:422
 msgid ""
@@ -887,7 +886,6 @@ msgstr ""
 "設為空字串，表示根目錄。"
 
 #: ../../library/zipfile.rst:593
-#, fuzzy
 msgid ""
 "The :class:`Path` class does not sanitize filenames within the ZIP archive. "
 "Unlike the :meth:`ZipFile.extract` and :meth:`ZipFile.extractall` methods, "
@@ -899,8 +897,8 @@ msgid ""
 msgstr ""
 ":class:`Path` 類別不會清理 ZIP 封存檔案內的檔名。與 :meth:`ZipFile.extract` "
 "和 :meth:`ZipFile.extractall` 方法不同，呼叫者有責任驗證或清理檔名，以防止路"
-"徑遍歷漏洞（例如，包含 \"..\" 或絕對路徑的檔名）。在處理不受信任的封存檔案"
-"時，請考慮使用 :func:`os.path.abspath` 解析檔名，並使用 :func:`os.path."
+"徑遍歷漏洞（例如，絕對路徑或帶有 \"..\" 元件的路徑）。在處理不受信任的封存檔"
+"案時，請考慮使用 :func:`os.path.abspath` 解析檔名，並使用 :func:`os.path."
 "commonpath` 與目標目錄進行核對。"
 
 #: ../../library/zipfile.rst:600

--- a/sphinx.po
+++ b/sphinx.po
@@ -365,9 +365,8 @@ msgid "Deprecated functionality"
 msgstr "已棄用的功能"
 
 #: ../../tools/templates/indexcontent.html:82
-#, fuzzy
 msgid "Other resources:"
-msgstr "其他資源"
+msgstr "其他資源："
 
 #: ../../tools/templates/indexcontent.html:85
 msgid "Python Packaging User Guide"
@@ -426,9 +425,8 @@ msgid "Complete table of contents"
 msgstr "完整內容列表"
 
 #: ../../tools/templates/indexcontent.html:108
-#, fuzzy
 msgid "All sections and subsections"
-msgstr "列出所有章節與小節"
+msgstr "所有章節與小節"
 
 #: ../../tools/templates/indexcontent.html:112
 msgid "Project information:"

--- a/whatsnew/3.10.po
+++ b/whatsnew/3.10.po
@@ -2775,16 +2775,15 @@ msgid "types"
 msgstr "types"
 
 #: ../../whatsnew/3.10.rst:1449
-#, fuzzy
 msgid ""
 "Reintroduce the :class:`types.EllipsisType`, :class:`types.NoneType` and :"
 "class:`types.NotImplementedType` classes, providing a new set of types "
 "readily interpretable by type checkers. (Contributed by Bas van Beek in :"
 "issue:`41810`.)"
 msgstr ""
-"重新引入 :data:`types.EllipsisType`、:data:`types.NoneType` 和 :data:`types."
-"NotImplementedType` 類別，提供一組易於型別檢查器直譯的新型別。（由 Bas van "
-"Beek 在 :issue:`41810` 中貢獻。）"
+"重新引入 :class:`types.EllipsisType`、:class:`types.NoneType` 和 :class:"
+"`types.NotImplementedType` 類別，提供一組易於型別檢查器直譯的新型別。（由 "
+"Bas van Beek 在 :issue:`41810` 中貢獻。）"
 
 #: ../../whatsnew/3.10.rst:1455
 msgid "typing"


### PR DESCRIPTION
Translated 34 fuzzy entries across 11 files introduced by the upstream sync with CPython. Key changes include:

- c-api/typehints: Update code example string (PEP 585 → generic type)
- library/constants: :data: → :class: for NoneType/EllipsisType/NotImplementedType
- library/io: Translate new RawIOBase.read() paragraph split + update EOF conditions
- library/math: Update frexp() description for finite nonzero number case
- library/ssl: Fix TLSv1_2/TLSv1_3 code example; split SSLSocket sentence
- library/stdtypes: Fix wrong cross-references (join/rsplit, not find/rindex)
- library/typing: "compatible" → "assignable"; ABC → 協定 for protocol classes
- library/urllib.request: Update example URLs from http:// to https://
- library/zipfile: Update security warning text; fix path traversal example
- sphinx: Add full-width colon to "其他資源："
- whatsnew/3.10: :data: → :class: for reintroduced type classes