### PR TITLE
Translate `library/profile.po`

### DIFF
--- a/library/profile.po
+++ b/library/profile.po
@@ -36,12 +36,16 @@ msgid ""
 "often and for how long various parts of the program executed. These "
 "statistics can be formatted into reports via the :mod:`pstats` module."
 msgstr ""
+":mod:`cProfile` 與 :mod:`profile` 為 Python 程式提供\\ :dfn:`確定性分析 "
+"(deterministic profiling)`。一份\\ :dfn:`分析資料 (profile)` 是一組統計數據，"
+"描述程式的各個部分執行的頻率和耗時。這些統計數據可以透過 :mod:`pstats` 模組格"
+"式化成報告。"
 
 #: ../../library/profile.rst:25
 msgid ""
 "The Python standard library provides two different implementations of the "
 "same profiling interface:"
-msgstr ""
+msgstr "Python 標準函式庫對相同的分析介面提供了兩種不同的實作："
 
 #: ../../library/profile.rst:28
 msgid ""
@@ -50,6 +54,9 @@ msgid ""
 "programs.  Based on :mod:`lsprof`, contributed by Brett Rosen and Ted "
 "Czotter."
 msgstr ""
+"建議大多數使用者使用 :mod:`cProfile`；它是一個 C 擴充模組，額外負擔合理，因此"
+"適合用來分析長時間執行的程式。它基於 :mod:`lsprof`，由 Brett Rosen 和 Ted "
+"Czotter 貢獻。"
 
 #: ../../library/profile.rst:33
 msgid ""
@@ -58,6 +65,9 @@ msgid ""
 "you're trying to extend the profiler in some way, the task might be easier "
 "with this module.  Originally designed and written by Jim Roskind."
 msgstr ""
+":mod:`profile` 是一個純 Python 模組，其介面被 :mod:`cProfile` 所模仿，但它會"
+"為被分析的程式增加可觀的額外負擔。如果你想以某種方式擴充分析器，使用此模組可"
+"能會讓任務更容易。最初由 Jim Roskind 設計並編寫。"
 
 #: ../../library/profile.rst:40
 msgid ""
@@ -68,10 +78,14 @@ msgid ""
 "for Python code, but not for C-level functions, and so the C code would seem "
 "faster than any Python one."
 msgstr ""
+"分析器模組的設計目的是為給定的程式提供執行分析資料，而非用於基準測試（要做基"
+"準測試的話，有 :mod:`timeit` 可以提供相當準確的結果）。這特別適用於將 Python "
+"程式碼與 C 程式碼進行基準測試的情況：分析器會為 Python 程式碼引入額外負擔，但"
+"不會為 C 層級的函式引入，因此 C 程式碼看起來會比任何 Python 程式碼更快。"
 
 #: ../../library/profile.rst:51
 msgid "Instant User's Manual"
-msgstr ""
+msgstr "即時使用者手冊"
 
 #: ../../library/profile.rst:53
 msgid ""
@@ -79,10 +93,12 @@ msgid ""
 "It provides a very brief overview, and allows a user to rapidly perform "
 "profiling on an existing application."
 msgstr ""
+"本節是為「不想閱讀手冊」的使用者所提供。它提供了一個非常簡短的概觀，並讓使用"
+"者能夠快速地對現有的應用程式進行分析。"
 
 #: ../../library/profile.rst:57
 msgid "To profile a function that takes a single argument, you can do::"
-msgstr ""
+msgstr "要分析一個接受單一引數的函式，你可以這樣做： ::"
 
 #: ../../library/profile.rst:59
 msgid ""
@@ -98,13 +114,13 @@ msgstr ""
 msgid ""
 "(Use :mod:`profile` instead of :mod:`cProfile` if the latter is not "
 "available on your system.)"
-msgstr ""
+msgstr "（如果你的系統上沒有 :mod:`cProfile`，請改用 :mod:`profile`。）"
 
 #: ../../library/profile.rst:66
 msgid ""
 "The above action would run :func:`re.compile` and print profile results like "
 "the following::"
-msgstr ""
+msgstr "上述動作會執行 :func:`re.compile` 並印出如下的分析結果： ::"
 
 #: ../../library/profile.rst:69
 msgid ""
@@ -143,6 +159,9 @@ msgid ""
 "The next line: ``Ordered by: cumulative time`` indicates the output is "
 "sorted by the ``cumtime`` values. The column headings include:"
 msgstr ""
+"第一行表示有 214 個呼叫被監測到。在這些呼叫中，有 207 個是\\ :dfn:`原始的 "
+"(primitive)`，意思是該呼叫不是透過遞迴所引發的。下一行 ``Ordered by: "
+"cumulative time`` 表示輸出是依照 ``cumtime`` 的值排序的。欄位標題包括："
 
 #: ../../library/profile.rst:88
 msgid "ncalls"
@@ -150,7 +169,7 @@ msgstr "ncalls"
 
 #: ../../library/profile.rst:89
 msgid "for the number of calls."
-msgstr ""
+msgstr "代表呼叫的次數。"
 
 #: ../../library/profile.rst:91
 msgid "tottime"
@@ -160,7 +179,7 @@ msgstr "tottime"
 msgid ""
 "for the total time spent in the given function (and excluding time made in "
 "calls to sub-functions)"
-msgstr ""
+msgstr "代表在給定函式中花費的總時間（不包括呼叫子函式所花費的時間）"
 
 #: ../../library/profile.rst:95 ../../library/profile.rst:102
 msgid "percall"
@@ -168,7 +187,7 @@ msgstr "percall"
 
 #: ../../library/profile.rst:96
 msgid "is the quotient of ``tottime`` divided by ``ncalls``"
-msgstr ""
+msgstr "是 ``tottime`` 除以 ``ncalls`` 的商"
 
 #: ../../library/profile.rst:98
 msgid "cumtime"
@@ -179,10 +198,12 @@ msgid ""
 "is the cumulative time spent in this and all subfunctions (from invocation "
 "till exit). This figure is accurate *even* for recursive functions."
 msgstr ""
+"是在此函式及其所有子函式中花費的累積時間（從呼叫到退出）。這個數字\\ *即使"
+"*\\ 對於遞迴函式也是準確的。"
 
 #: ../../library/profile.rst:103
 msgid "is the quotient of ``cumtime`` divided by primitive calls"
-msgstr ""
+msgstr "是 ``cumtime`` 除以原始呼叫次數的商"
 
 #: ../../library/profile.rst:105
 msgid "filename:lineno(function)"
@@ -190,7 +211,7 @@ msgstr "filename:lineno(function)"
 
 #: ../../library/profile.rst:106
 msgid "provides the respective data of each function"
-msgstr ""
+msgstr "提供每個函式各自的資料"
 
 #: ../../library/profile.rst:108
 msgid ""
@@ -200,12 +221,17 @@ msgid ""
 "the function does not recurse, these two values are the same, and only the "
 "single figure is printed."
 msgstr ""
+"當第一欄有兩個數字時（例如 ``3/1``），表示該函式發生了遞迴。第二個值是原始呼"
+"叫的次數，而前者是呼叫的總次數。請注意，當函式沒有遞迴時，這兩個值是相同的，"
+"並且只會印出單一數字。"
 
 #: ../../library/profile.rst:114
 msgid ""
 "Instead of printing the output at the end of the profile run, you can save "
 "the results to a file by specifying a filename to the :func:`run` function::"
 msgstr ""
+"除了在分析執行結束時印出輸出之外，你也可以透過為 :func:`run` 函式指定一個檔案"
+"名稱來將結果儲存到檔案中： ::"
 
 #: ../../library/profile.rst:117
 msgid ""
@@ -222,12 +248,15 @@ msgid ""
 "The :class:`pstats.Stats` class reads profile results from a file and "
 "formats them in various ways."
 msgstr ""
+":class:`pstats.Stats` 類別會從檔案中讀取分析結果，並以各種方式將其格式化。"
 
 #: ../../library/profile.rst:128
 msgid ""
 "The files :mod:`cProfile` and :mod:`profile` can also be invoked as a script "
 "to profile another script.  For example::"
 msgstr ""
+":mod:`cProfile` 與 :mod:`profile` 這兩個檔案也可以作為腳本被叫用，以分析另一"
+"個腳本。例如： ::"
 
 #: ../../library/profile.rst:131
 msgid ""
@@ -237,7 +266,7 @@ msgstr ""
 
 #: ../../library/profile.rst:135
 msgid "Writes the profile results to a file instead of to stdout."
-msgstr ""
+msgstr "將分析結果寫入檔案，而不是寫入 stdout。"
 
 #: ../../library/profile.rst:139
 msgid ""
@@ -245,10 +274,12 @@ msgid ""
 "the output by. This only applies when :option:`-o <cProfile -o>` is not "
 "supplied."
 msgstr ""
+"指定 :func:`~pstats.Stats.sort_stats` 的其中一個排序值來排序輸出。這只在沒有"
+"提供 :option:`-o <cProfile -o>` 時適用。"
 
 #: ../../library/profile.rst:145
 msgid "Specifies that a module is being profiled instead of a script."
-msgstr ""
+msgstr "指定要分析的是模組而非腳本。"
 
 #: ../../library/profile.rst:147
 msgid "Added the ``-m`` option to :mod:`cProfile`."
@@ -264,6 +295,8 @@ msgid ""
 "methods for manipulating and printing the data saved into a profile results "
 "file::"
 msgstr ""
+":mod:`pstats` 模組的 :class:`~pstats.Stats` 類別有多種方法可用來操作和印出儲"
+"存在分析結果檔案中的資料： ::"
 
 #: ../../library/profile.rst:156
 msgid ""
@@ -285,6 +318,10 @@ msgid ""
 "printed. The :meth:`~pstats.Stats.print_stats` method printed out all the "
 "statistics.  You might try the following sort calls::"
 msgstr ""
+":meth:`~pstats.Stats.strip_dirs` 方法移除了所有模組名稱中多餘的路"
+"徑。:meth:`~pstats.Stats.sort_stats` 方法依照所印出的標準 module/line/name 字"
+"串對所有項目進行排序。:meth:`~pstats.Stats.print_stats` 方法印出所有的統計數"
+"據。你可以嘗試以下的排序呼叫： ::"
 
 #: ../../library/profile.rst:167
 msgid ""
@@ -300,6 +337,8 @@ msgid ""
 "call will print out the statistics.  The following are some interesting "
 "calls to experiment with::"
 msgstr ""
+"第一個呼叫實際上會依函式名稱對串列進行排序，而第二個呼叫則會印出統計數據。以"
+"下是一些有趣的、可供實驗的呼叫： ::"
 
 #: ../../library/profile.rst:174
 msgid "p.sort_stats(SortKey.CUMULATIVE).print_stats(10)"
@@ -311,12 +350,14 @@ msgid ""
 "prints the ten most significant lines.  If you want to understand what "
 "algorithms are taking time, the above line is what you would use."
 msgstr ""
+"這會依函式中的累積時間對分析資料進行排序，然後只印出最重要的十行。如果你想了"
+"解哪些演算法在耗費時間，上面這行就是你會用到的。"
 
 #: ../../library/profile.rst:180
 msgid ""
 "If you were looking to see what functions were looping a lot, and taking a "
 "lot of time, you would do::"
-msgstr ""
+msgstr "如果你想看看哪些函式大量地迴圈執行並耗費了很多時間，你可以這樣做： ::"
 
 #: ../../library/profile.rst:183
 msgid "p.sort_stats(SortKey.TIME).print_stats(10)"
@@ -326,11 +367,11 @@ msgstr "p.sort_stats(SortKey.TIME).print_stats(10)"
 msgid ""
 "to sort according to time spent within each function, and then print the "
 "statistics for the top ten functions."
-msgstr ""
+msgstr "來依每個函式內部所花費的時間進行排序，然後印出前十個函式的統計數據。"
 
 #: ../../library/profile.rst:188
 msgid "You might also try::"
-msgstr ""
+msgstr "你也可以嘗試： ::"
 
 #: ../../library/profile.rst:190
 msgid "p.sort_stats(SortKey.FILENAME).print_stats('__init__')"
@@ -342,6 +383,8 @@ msgid ""
 "statistics for only the class init methods (since they are spelled with "
 "``__init__`` in them).  As one final example, you could try::"
 msgstr ""
+"這會依檔案名稱對所有統計數據進行排序，然後只印出類別 init 方法的統計數據（因"
+"為它們的名稱中都拼寫有 ``__init__``）。作為最後一個範例，你可以嘗試： ::"
 
 #: ../../library/profile.rst:196
 msgid "p.sort_stats(SortKey.TIME, SortKey.CUMULATIVE).print_stats(.5, 'init')"
@@ -355,12 +398,17 @@ msgid ""
 "size, then only lines containing ``init`` are maintained, and that sub-sub-"
 "list is printed."
 msgstr ""
+"這一行以時間作為主要鍵、累積時間作為次要鍵來對統計數據進行排序，然後印出部分"
+"統計數據。具體來說，串列首先被縮減到其原始大小的 50%（即 ``.5``），然後只保留"
+"包含 ``init`` 的行，並印出該子子串列。"
 
 #: ../../library/profile.rst:203
 msgid ""
 "If you wondered what functions called the above functions, you could now "
 "(``p`` is still sorted according to the last criteria) do::"
 msgstr ""
+"如果你想知道是哪些函式呼叫了上述函式，你現在可以這樣做（``p`` 仍依照上一個條"
+"件排序）： ::"
 
 #: ../../library/profile.rst:206
 msgid "p.print_callers(.5, 'init')"
@@ -368,13 +416,13 @@ msgstr "p.print_callers(.5, 'init')"
 
 #: ../../library/profile.rst:208
 msgid "and you would get a list of callers for each of the listed functions."
-msgstr ""
+msgstr "然後你會得到一份列出每個函式之呼叫者的串列。"
 
 #: ../../library/profile.rst:210
 msgid ""
 "If you want more functionality, you're going to have to read the manual, or "
 "guess what the following functions do::"
-msgstr ""
+msgstr "如果你想要更多的功能，你就得閱讀手冊，或猜猜下列函式的作用： ::"
 
 #: ../../library/profile.rst:213
 msgid ""
@@ -390,6 +438,9 @@ msgid ""
 "reading and examining profile dumps.  It has a simple line-oriented "
 "interface (implemented using :mod:`cmd`) and interactive help."
 msgstr ""
+"作為腳本被叫用時，:mod:`pstats` 模組是一個統計瀏覽器，用來讀取和檢查分析傾印"
+"（dump）。它有一個簡單的、以行為導向的介面（使用 :mod:`cmd` 實作）和互動式的"
+"說明。"
 
 #: ../../library/profile.rst:221
 msgid ":mod:`profile` and :mod:`!cProfile` Module Reference"
@@ -406,6 +457,8 @@ msgid ""
 "This function takes a single argument that can be passed to the :func:`exec` "
 "function, and an optional file name.  In all cases this routine executes::"
 msgstr ""
+"此函式接受一個可傳遞給 :func:`exec` 函式的單一引數，以及一個可選的檔案名稱。"
+"在所有情況下，此常式都會執行： ::"
 
 #: ../../library/profile.rst:235
 msgid "exec(command, __main__.__dict__, __main__.__dict__)"
@@ -419,12 +472,17 @@ msgid ""
 "specified, it is passed to this :class:`~pstats.Stats` instance to control "
 "how the results are sorted."
 msgstr ""
+"並從執行過程中收集分析統計數據。如果沒有提供檔案名稱，則此函式會自動建立一"
+"個 :class:`~pstats.Stats` 實例並印出一份簡單的分析報告。如果指定了排序值，它"
+"會被傳遞給這個 :class:`~pstats.Stats` 實例以控制結果的排序方式。"
 
 #: ../../library/profile.rst:245
 msgid ""
 "This function is similar to :func:`run`, with added arguments to supply the "
 "globals and locals mappings for the *command* string. This routine executes::"
 msgstr ""
+"此函式與 :func:`run` 類似，但增加了引數以提供 *command* 字串的 globals 和 "
+"locals 對映。此常式會執行： ::"
 
 #: ../../library/profile.rst:249
 msgid "exec(command, globals, locals)"
@@ -432,13 +490,15 @@ msgstr "exec(command, globals, locals)"
 
 #: ../../library/profile.rst:251
 msgid "and gathers profiling statistics as in the :func:`run` function above."
-msgstr ""
+msgstr "並如同上述的 :func:`run` 函式一樣收集分析統計數據。"
 
 #: ../../library/profile.rst:255
 msgid ""
 "This class is normally only used if more precise control over profiling is "
 "needed than what the :func:`cProfile.run` function provides."
 msgstr ""
+"通常只有在需要比 :func:`cProfile.run` 函式所提供更精確的分析控制時，才會使用"
+"此類別。"
 
 #: ../../library/profile.rst:258
 msgid ""
@@ -449,12 +509,18 @@ msgid ""
 "example, if the timer returns times measured in thousands of seconds, the "
 "time unit would be ``.001``."
 msgstr ""
+"可以透過 *timer* 引數提供一個自訂的計時器來測量程式碼執行所需的時間。它必須是"
+"一個回傳代表目前時間之單一數字的函式。如果該數字是整數，*timeunit* 會指定一個"
+"乘數來指定每個時間單位的持續時間。例如，如果計時器回傳以千分之一秒為單位測量"
+"的時間，那麼時間單位將會是 ``.001``。"
 
 #: ../../library/profile.rst:265
 msgid ""
 "Directly using the :class:`Profile` class allows formatting profile results "
 "without writing the profile data to a file::"
 msgstr ""
+"直接使用 :class:`Profile` 類別可以在不將分析資料寫入檔案的情況下格式化分析結"
+"果： ::"
 
 #: ../../library/profile.rst:268
 msgid ""
@@ -487,6 +553,8 @@ msgid ""
 "The :class:`Profile` class can also be used as a context manager (supported "
 "only in :mod:`!cProfile` module. see :ref:`typecontextmanager`)::"
 msgstr ""
+":class:`Profile` 類別也可以作為情境管理器使用（僅 :mod:`!cProfile` 模組支援，"
+"請參閱 :ref:`typecontextmanager`）： ::"
 
 #: ../../library/profile.rst:283
 msgid ""
@@ -510,23 +578,25 @@ msgstr "新增情境管理器的支援。"
 
 #: ../../library/profile.rst:295
 msgid "Start collecting profiling data. Only in :mod:`!cProfile`."
-msgstr ""
+msgstr "開始收集分析資料。僅在 :mod:`!cProfile` 中。"
 
 #: ../../library/profile.rst:299
 msgid "Stop collecting profiling data. Only in :mod:`!cProfile`."
-msgstr ""
+msgstr "停止收集分析資料。僅在 :mod:`!cProfile` 中。"
 
 #: ../../library/profile.rst:303
 msgid ""
 "Stop collecting profiling data and record the results internally as the "
 "current profile."
-msgstr ""
+msgstr "停止收集分析資料，並在內部將結果記錄為目前的分析資料。"
 
 #: ../../library/profile.rst:308
 msgid ""
 "Create a :class:`~pstats.Stats` object based on the current profile and "
 "print the results to stdout."
 msgstr ""
+"根據目前的分析資料建立一個 :class:`~pstats.Stats` 物件，並將結果印出到 "
+"stdout。"
 
 #: ../../library/profile.rst:311
 msgid ""
@@ -534,28 +604,31 @@ msgid ""
 "statistics. It accepts a single key or a tuple of keys to enable multi-level "
 "sorting, as in :func:`Stats.sort_stats <pstats.Stats.sort_stats>`."
 msgstr ""
+"*sort* 參數指定所顯示之統計數據的排序順序。它接受單一鍵或一個由多個鍵組成的元"
+"組以啟用多層級排序，如同 :func:`Stats.sort_stats <pstats.Stats.sort_stats>` "
+"中那樣。"
 
 #: ../../library/profile.rst:315
 msgid ":meth:`~Profile.print_stats` now accepts a tuple of keys."
-msgstr ""
+msgstr ":meth:`~Profile.print_stats` 現在接受一個由多個鍵組成的元組。"
 
 #: ../../library/profile.rst:320
 msgid "Write the results of the current profile to *filename*."
-msgstr ""
+msgstr "將目前分析資料的結果寫入 *filename*。"
 
 #: ../../library/profile.rst:324
 msgid "Profile the cmd via :func:`exec`."
-msgstr ""
+msgstr "透過 :func:`exec` 分析 cmd。"
 
 #: ../../library/profile.rst:328
 msgid ""
 "Profile the cmd via :func:`exec` with the specified global and local "
 "environment."
-msgstr ""
+msgstr "以指定的全域和區域環境，透過 :func:`exec` 分析 cmd。"
 
 #: ../../library/profile.rst:333
 msgid "Profile ``func(*args, **kwargs)``"
-msgstr ""
+msgstr "分析 ``func(*args, **kwargs)``"
 
 #: ../../library/profile.rst:335
 msgid ""
@@ -564,6 +637,9 @@ msgid ""
 "during the called command/function execution) no profiling results will be "
 "printed."
 msgstr ""
+"請注意，分析只有在被呼叫的命令／函式實際有回傳時才會運作。如果直譯器被終止"
+"（例如在被呼叫的命令／函式執行期間透過 :func:`sys.exit` 呼叫），則不會印出任"
+"何分析結果。"
 
 #: ../../library/profile.rst:343
 msgid "The :class:`Stats` Class"
@@ -572,7 +648,7 @@ msgstr ":class:`Stats` 類別"
 #: ../../library/profile.rst:345
 msgid ""
 "Analysis of the profiler data is done using the :class:`~pstats.Stats` class."
-msgstr ""
+msgstr "分析器資料的分析是使用 :class:`~pstats.Stats` 類別來完成的。"
 
 #: ../../library/profile.rst:352
 msgid ""
@@ -580,6 +656,9 @@ msgid ""
 "*filename* (or list of filenames) or from a :class:`Profile` instance. "
 "Output will be printed to the stream specified by *stream*."
 msgstr ""
+"此類別建構函式會從一個 *filename*\\ （或檔案名稱串列）或從一"
+"個 :class:`Profile` 實例建立一個「統計物件」的實例。輸出會被印出到由 "
+"*stream* 所指定的串流中。"
 
 #: ../../library/profile.rst:356
 msgid ""
@@ -594,12 +673,20 @@ msgid ""
 "existing :class:`~pstats.Stats` object, the :meth:`~pstats.Stats.add` method "
 "can be used."
 msgstr ""
+"由上述建構函式所選的檔案必須是由對應版本的 :mod:`profile` 或 :mod:`cProfile` "
+"所建立的。具體來說，與此分析器的未來版本\\ *沒有*\\ 檔案相容性保證，與其他分"
+"析器產生的檔案、或同一分析器在不同作業系統上執行所產生的檔案也都不相容。如果"
+"提供了多個檔案，所有相同函式的統計數據都會被合併，因此可以在單一報告中考量多"
+"個行程的整體檢視。如果需要將額外的檔案與現有 :class:`~pstats.Stats` 物件中的"
+"資料合併，則可以使用 :meth:`~pstats.Stats.add` 方法。"
 
 #: ../../library/profile.rst:367
 msgid ""
 "Instead of reading the profile data from a file, a :class:`cProfile.Profile` "
 "or :class:`profile.Profile` object can be used as the profile data source."
 msgstr ""
+"除了從檔案讀取分析資料之外，也可以使用 :class:`cProfile.Profile` "
+"或 :class:`profile.Profile` 物件作為分析資料來源。"
 
 #: ../../library/profile.rst:370
 msgid ":class:`Stats` objects have the following methods:"
@@ -618,6 +705,12 @@ msgid ""
 "name), then the statistics for these two entries are accumulated into a "
 "single entry."
 msgstr ""
+":class:`Stats` 類別的此方法會從檔案名稱中移除所有前導的路徑資訊。它在縮減印出"
+"內容的大小以符合（接近）80 欄方面非常有用。此方法會修改物件，且被移除的資訊會"
+"遺失。在執行移除操作後，該物件被認為其項目處於「隨機」順序，就如同物件初始化"
+"和載入之後一樣。如果 :meth:`~pstats.Stats.strip_dirs` 導致兩個函式名稱無法區"
+"分（它們位於相同檔案名稱的同一行，且有相同的函式名稱），那麼這兩個項目的統計"
+"數據會被累加成單一項目。"
 
 #: ../../library/profile.rst:388
 msgid ""
@@ -627,6 +720,10 @@ msgid ""
 "func:`cProfile.run`. Statistics for identically named (re: file, line, name) "
 "functions are automatically accumulated into single function statistics."
 msgstr ""
+":class:`Stats` 類別的此方法會將額外的分析資訊累加到目前的分析物件中。它的引數"
+"應指向由對應版本的 :func:`profile.run` 或 :func:`cProfile.run` 所建立的檔案名"
+"稱。名稱相同（即 file、line、name）的函式的統計數據會自動累加成單一函式的統計"
+"數據。"
 
 #: ../../library/profile.rst:398
 msgid ""
@@ -635,6 +732,9 @@ msgid ""
 "it already exists.  This is equivalent to the method of the same name on "
 "the :class:`profile.Profile` and :class:`cProfile.Profile` classes."
 msgstr ""
+"將載入到 :class:`Stats` 物件中的資料儲存到名為 *filename* 的檔案中。如果該檔"
+"案不存在，則會建立它；如果它已存在，則會被覆寫。這等同"
+"於 :class:`profile.Profile` 和 :class:`cProfile.Profile` 類別上的同名方法。"
 
 #: ../../library/profile.rst:406
 msgid ""
@@ -645,6 +745,10 @@ msgid ""
 "advantage over the string argument in that it is more robust and less error "
 "prone."
 msgstr ""
+"此方法透過依照所提供的條件進行排序來修改 :class:`Stats` 物件。引數可以是字串"
+"或用來識別排序依據的 SortKey enum（範例：``'time'``、``'name'``、"
+"``SortKey.TIME`` 或 ``SortKey.NAME``）。SortKey enum 引數相較於字串引數的優勢"
+"在於它更穩健且較不易出錯。"
 
 #: ../../library/profile.rst:413
 msgid ""
@@ -654,24 +758,27 @@ msgid ""
 "entries according to their function name, and resolve all ties (identical "
 "function names) by sorting by file name."
 msgstr ""
+"當提供超過一個鍵時，當前面所選的所有鍵都相等時，會將額外的鍵用作次要條件。例"
+"如，``sort_stats(SortKey.NAME, SortKey.FILE)`` 會依函式名稱對所有項目進行排"
+"序，並透過依檔案名稱排序來解決所有相等的情況（相同的函式名稱）。"
 
 #: ../../library/profile.rst:419
 msgid ""
 "For the string argument, abbreviations can be used for any key names, as "
 "long as the abbreviation is unambiguous."
-msgstr ""
+msgstr "對於字串引數，只要縮寫沒有歧義，任何鍵名都可以使用縮寫。"
 
 #: ../../library/profile.rst:422
 msgid "The following are the valid string and SortKey:"
-msgstr ""
+msgstr "以下是有效的字串和 SortKey："
 
 #: ../../library/profile.rst:425
 msgid "Valid String Arg"
-msgstr ""
+msgstr "有效的字串引數"
 
 #: ../../library/profile.rst:425
 msgid "Valid enum Arg"
-msgstr ""
+msgstr "有效的 enum 引數"
 
 #: ../../library/profile.rst:425
 msgid "Meaning"
@@ -687,7 +794,7 @@ msgstr "SortKey.CALLS"
 
 #: ../../library/profile.rst:427 ../../library/profile.rst:439
 msgid "call count"
-msgstr ""
+msgstr "呼叫次數"
 
 #: ../../library/profile.rst:429
 msgid "``'cumulative'``"
@@ -699,7 +806,7 @@ msgstr "SortKey.CUMULATIVE"
 
 #: ../../library/profile.rst:429 ../../library/profile.rst:431
 msgid "cumulative time"
-msgstr ""
+msgstr "累積時間"
 
 #: ../../library/profile.rst:431
 msgid "``'cumtime'``"
@@ -746,7 +853,7 @@ msgstr "SortKey.PCALLS"
 
 #: ../../library/profile.rst:441
 msgid "primitive call count"
-msgstr ""
+msgstr "原始呼叫次數"
 
 #: ../../library/profile.rst:443
 msgid "``'line'``"
@@ -770,7 +877,7 @@ msgstr "SortKey.NAME"
 
 #: ../../library/profile.rst:445
 msgid "function name"
-msgstr ""
+msgstr "函式名稱"
 
 #: ../../library/profile.rst:447
 msgid "``'nfl'``"
@@ -782,7 +889,7 @@ msgstr "SortKey.NFL"
 
 #: ../../library/profile.rst:447
 msgid "name/file/line"
-msgstr ""
+msgstr "名稱/檔案/行"
 
 #: ../../library/profile.rst:449
 msgid "``'stdname'``"
@@ -794,7 +901,7 @@ msgstr "SortKey.STDNAME"
 
 #: ../../library/profile.rst:449
 msgid "standard name"
-msgstr ""
+msgstr "標準名稱"
 
 #: ../../library/profile.rst:451
 msgid "``'time'``"
@@ -806,7 +913,7 @@ msgstr "SortKey.TIME"
 
 #: ../../library/profile.rst:451 ../../library/profile.rst:453
 msgid "internal time"
-msgstr ""
+msgstr "內部時間"
 
 #: ../../library/profile.rst:453
 msgid "``'tottime'``"
@@ -825,6 +932,13 @@ msgid ""
 "``sort_stats(SortKey.NFL)`` is the same as ``sort_stats(SortKey.NAME, "
 "SortKey.FILENAME, SortKey.LINE)``."
 msgstr ""
+"請注意，所有對統計數據的排序都是以降序進行（將最耗時的項目放在最前面），而名"
+"稱、檔案和行號的搜尋則是以升序（按字母順序）進行。``SortKey.NFL`` 和 "
+"``SortKey.STDNAME`` 之間的細微差別在於，標準名稱是對所印出名稱的排序，這表示"
+"內嵌的行號會以一種奇怪的方式被比較。例如，第 3、20 和 40 行（如果檔案名稱相同"
+"的話）會以字串順序 20、3 和 40 出現。相對地，``SortKey.NFL`` 則是對行號進行數"
+"值比較。事實上，``sort_stats(SortKey.NFL)`` 與 ``sort_stats(SortKey.NAME, "
+"SortKey.FILENAME, SortKey.LINE)`` 是相同的。"
 
 #: ../../library/profile.rst:467
 msgid ""
@@ -834,10 +948,14 @@ msgid ""
 "style format (numeric) is used, only one sort key (the numeric key) will be "
 "used, and additional arguments will be silently ignored."
 msgstr ""
+"基於向後相容的原因，允許使用數字引數 ``-1``、``0``、``1`` 和 ``2``。它們分別"
+"被解讀為 ``'stdname'``、``'calls'``、``'time'`` 和 ``'cumulative'``。如果使用"
+"這種舊式格式（數字），則只會使用一個排序鍵（該數字鍵），且額外的引數會被默默"
+"地忽略。"
 
 #: ../../library/profile.rst:475
 msgid "Added the SortKey enum."
-msgstr ""
+msgstr "新增 SortKey enum。"
 
 #: ../../library/profile.rst:480
 msgid ""
@@ -845,12 +963,16 @@ msgid ""
 "list within the object.  Note that by default ascending vs descending order "
 "is properly selected based on the sort key of choice."
 msgstr ""
+":class:`Stats` 類別的此方法會反轉物件內基本串列的順序。請注意，預設情況下，升"
+"序或降序會根據所選的排序鍵被適當地選定。"
 
 #: ../../library/profile.rst:490
 msgid ""
 "This method for the :class:`Stats` class prints out a report as described in "
 "the :func:`profile.run` definition."
 msgstr ""
+":class:`Stats` 類別的此方法會印出一份報告，如 :func:`profile.run` 定義中所"
+"述。"
 
 #: ../../library/profile.rst:493
 msgid ""
@@ -858,6 +980,9 @@ msgid ""
 "sort_stats` operation done on the object (subject to caveats in :meth:"
 "`~pstats.Stats.add` and :meth:`~pstats.Stats.strip_dirs`)."
 msgstr ""
+"印出的順序是基於對物件所做的最後一次 :meth:`~pstats.Stats.sort_stats` 操作"
+"（受限於 :meth:`~pstats.Stats.add` 和 :meth:`~pstats.Stats.strip_dirs` 中的注"
+"意事項）。"
 
 #: ../../library/profile.rst:498
 msgid ""
@@ -870,6 +995,11 @@ msgid ""
 "several restrictions are provided, then they are applied sequentially. For "
 "example::"
 msgstr ""
+"所提供的引數（如果有的話）可用來將串列限縮為重要的項目。一開始，串列被視為被"
+"分析函式的完整集合。每個限制條件可以是一個整數（用來選擇行數），或是一個介於 "
+"0.0 和 1.0（含）之間的十進位小數（用來選擇行的百分比），或是一個會被解讀為正"
+"規表示式的字串（用來對所印出的標準名稱進行模式匹配）。如果提供了多個限制條"
+"件，則它們會被依序套用。例如： ::"
 
 #: ../../library/profile.rst:507
 msgid "print_stats(.1, 'foo:')"
@@ -881,6 +1011,8 @@ msgid ""
 "functions that were part of filename :file:`.\\*foo:`.  In contrast, the "
 "command::"
 msgstr ""
+"會先將印出內容限制為串列的前 10%，然後只印出屬於檔案名稱 :file:`.\\*foo:` 之"
+"一部分的函式。相對地，以下命令： ::"
 
 #: ../../library/profile.rst:513
 msgid "print_stats('foo:', .1)"
@@ -891,6 +1023,8 @@ msgid ""
 "would limit the list to all functions having file names :file:`.\\*foo:`, "
 "and then proceed to only print the first 10% of them."
 msgstr ""
+"會將串列限制為所有檔案名稱為 :file:`.\\*foo:` 的函式，然後接著只印出它們之中"
+"的前 10%。"
 
 #: ../../library/profile.rst:521
 msgid ""
@@ -901,6 +1035,10 @@ msgid ""
 "own line.  The format differs slightly depending on the profiler that "
 "produced the stats:"
 msgstr ""
+":class:`Stats` 類別的此方法會印出一份串列，列出在被分析的資料庫中呼叫了每個函"
+"式的所有函式。其排序與 :meth:`~pstats.Stats.print_stats` 所提供的相同，限制引"
+"數的定義也相同。每個呼叫者各佔一行顯示。其格式會依產生統計數據的分析器而略有"
+"不同："
 
 #: ../../library/profile.rst:528
 msgid ""
@@ -909,6 +1047,9 @@ msgid ""
 "non-parenthesized number repeats the cumulative time spent in the function "
 "at the right."
 msgstr ""
+"使用 :mod:`profile` 時，每個呼叫者之後會在括號中顯示一個數字，以表示這個特定"
+"呼叫被進行了多少次。為了方便，右側會有第二個不加括號的數字重複顯示在該函式中"
+"花費的累積時間。"
 
 #: ../../library/profile.rst:533
 msgid ""
@@ -916,6 +1057,8 @@ msgid ""
 "of times this specific call was made, and the total and cumulative times "
 "spent in the current function while it was invoked by this specific caller."
 msgstr ""
+"使用 :mod:`cProfile` 時，每個呼叫者之前會有三個數字：這個特定呼叫被進行的次"
+"數，以及當目前函式被這個特定呼叫者叫用時，在其中花費的總時間和累積時間。"
 
 #: ../../library/profile.rst:541
 msgid ""
@@ -924,6 +1067,9 @@ msgid ""
 "direction of calls (re: called vs was called by), the arguments and ordering "
 "are identical to the :meth:`~pstats.Stats.print_callers` method."
 msgstr ""
+":class:`Stats` 類別的此方法會印出一份串列，列出由所指定函式呼叫的所有函式。除"
+"了呼叫方向相反之外（即「呼叫」與「被呼叫」的差別），其引數和排序都"
+"與 :meth:`~pstats.Stats.print_callers` 方法相同。"
 
 #: ../../library/profile.rst:549
 msgid ""
@@ -932,16 +1078,21 @@ msgid ""
 "instance holds information related to the function's profile such as how "
 "long the function took to run, how many times it was called, etc..."
 msgstr ""
+"此方法回傳一個 StatsProfile 的實例，其中包含一個函式名稱到 FunctionProfile 實"
+"例的對映。每個 FunctionProfile 實例都存有與該函式分析相關的資訊，例如該函式執"
+"行了多久、被呼叫了多少次等等。"
 
 #: ../../library/profile.rst:554
 msgid ""
 "Added the following dataclasses: StatsProfile, FunctionProfile. Added the "
 "following function: get_stats_profile."
 msgstr ""
+"新增以下資料類別（dataclass）：StatsProfile、FunctionProfile。新增以下函式："
+"get_stats_profile。"
 
 #: ../../library/profile.rst:561
 msgid "What Is Deterministic Profiling?"
-msgstr ""
+msgstr "什麼是確定性分析？"
 
 #: ../../library/profile.rst:563
 msgid ""
@@ -955,6 +1106,13 @@ msgid ""
 "be instrumented), but provides only relative indications of where time is "
 "being spent."
 msgstr ""
+":dfn:`確定性分析 (Deterministic profiling)` 意在反映這樣一個事實：所有的\\ *"
+"函式呼叫 (function call)*、*函式回傳 (function return)* 和\\ *例外 "
+"(exception)* 事件都會被監測，並對這些事件之間的間隔（在此期間使用者的程式碼正"
+"在執行）進行精確的計時。相對地，:dfn:`統計分析 (statistical profiling)`\\ "
+"（本模組不會執行）會隨機取樣有效的指令指標，並推斷時間花在哪裡。後者的技術傳"
+"統上涉及較少的額外負擔（因為程式碼不需要被插樁），但只能相對地指出時間花費於"
+"何處。"
 
 #: ../../library/profile.rst:572
 msgid ""
@@ -967,6 +1125,11 @@ msgid ""
 "deterministic profiling is not that expensive, yet provides extensive run "
 "time statistics about the execution of a Python program."
 msgstr ""
+"在 Python 中，由於執行期間有一個直譯器處於活躍狀態，因此進行確定性分析時並不"
+"需要存在插樁過的程式碼。Python 會自動為每個事件提供一個 :dfn:`鉤子 (hook)`\\ "
+"（可選的回呼）。此外，Python 直譯式的本質往往會為執行增加非常多的額外負擔，因"
+"此確定性分析在典型的應用程式中往往只會增加少量的處理額外負擔。其結果就是，確"
+"定性分析並不那麼昂貴，但卻能提供關於 Python 程式執行的大量執行期統計數據。"
 
 #: ../../library/profile.rst:581
 msgid ""
@@ -979,6 +1142,11 @@ msgid ""
 "statistics for recursive implementations of algorithms to be directly "
 "compared to iterative implementations."
 msgstr ""
+"呼叫次數的統計數據可用來識別程式碼中的錯誤（出人意料的次數），以及識別可能的"
+"行內展開點（高呼叫次數）。內部時間的統計數據可用來識別應該仔細最佳化的「熱迴"
+"圈」。累積時間的統計數據應用來識別演算法選擇上的高層級錯誤。請注意，此分析器"
+"對累積時間的特殊處理方式，使得演算法之遞迴實作的統計數據可以直接與疊代實作進"
+"行比較。"
 
 #: ../../library/profile.rst:594
 msgid "Limitations"
@@ -994,6 +1162,10 @@ msgid ""
 "then the \"error\" will tend to average out. Unfortunately, removing this "
 "first error induces a second source of error."
 msgstr ""
+"其中一個限制與計時資訊的準確度有關。確定性分析器在準確度方面存在一個根本性的"
+"問題。最明顯的限制是底層的「時鐘」（通常）只以大約 .001 秒的速率滴答計時。因"
+"此沒有任何測量會比底層時鐘更準確。如果進行了足夠多的測量，那麼「誤差」往往會"
+"被平均掉。不幸的是，消除這第一種誤差會引發第二種誤差來源。"
 
 #: ../../library/profile.rst:604
 msgid ""
@@ -1007,6 +1179,12 @@ msgid ""
 "fashion is typically less than the accuracy of the clock (less than one "
 "clock tick), but it *can* accumulate and become very significant."
 msgstr ""
+"第二個問題是，從一個事件被分派出去，到分析器呼叫取得時間以實際\\ *取得*\\ 時"
+"鐘的狀態，這之間「需要一段時間」。同樣地，從取得時鐘的值（並隨後將其暫存起"
+"來），到使用者的程式碼再次開始執行，退出分析器事件處理函式時也有一定的延遲。"
+"其結果是，被呼叫很多次、或呼叫許多函式的函式，通常會累積這種誤差。以這種方式"
+"累積的誤差通常小於時鐘的準確度（小於一個時鐘滴答），但它\\ *可能*\\ 累積並變"
+"得非常顯著。"
 
 #: ../../library/profile.rst:614
 msgid ""
@@ -1021,6 +1199,12 @@ msgid ""
 "calibrated your profiler, and the results are actually better than without "
 "calibration."
 msgstr ""
+"這個問題對於 :mod:`profile` 來說比對於額外負擔較低的 :mod:`cProfile` 來說更為"
+"重要。基於這個原因，:mod:`profile` 提供了一種針對給定平台進行自我校正的方法，"
+"使得這種誤差可以被機率性地（平均而言）消除。在分析器被校正之後，它會更準確"
+"（就最小平方意義而言），但它有時會產生負數（當呼叫次數異常低，且機率之神與你"
+"作對時 :-)）。不要被分析資料中的負數嚇到。它們\\ *只*\\ 應在你已經校正過你的"
+"分析器、且結果實際上比未校正時更好的情況下才會出現。"
 
 #: ../../library/profile.rst:628
 msgid "Calibration"
@@ -1034,6 +1218,9 @@ msgid ""
 "following procedure can be used to obtain a better constant for a given "
 "platform (see :ref:`profile-limitations`). ::"
 msgstr ""
+":mod:`profile` 模組的分析器會從每個事件的處理時間中減去一個常數，以補償呼叫時"
+"間函式和暫存結果的額外負擔。預設情況下，此常數為 0。以下程序可用來為給定平台"
+"取得一個更好的常數（請參閱 :ref:`profile-limitations`）。 ::"
 
 #: ../../library/profile.rst:636
 msgid ""
@@ -1056,6 +1243,10 @@ msgid ""
 "Python's time.process_time() as the timer, the magical number is about "
 "4.04e-6."
 msgstr ""
+"此方法會直接執行由引數所給定數量的 Python 呼叫，然後再次在分析器下執行，並測"
+"量兩者的時間。接著它會計算每個分析器事件的隱藏額外負擔，並將其作為浮點數回"
+"傳。例如，在一台執行 macOS 的 1.8Ghz Intel Core i5 上，使用 Python 的 "
+"time.process_time() 作為計時器，這個神奇的數字大約是 4.04e-6。"
 
 #: ../../library/profile.rst:647
 msgid ""
@@ -1063,11 +1254,14 @@ msgid ""
 "computer is *very* fast, or your timer function has poor resolution, you "
 "might have to pass 100000, or even 1000000, to get consistent results."
 msgstr ""
+"這個練習的目的是要得到一個相當一致的結果。如果你的電腦\\ *非常*\\ 快，或者你"
+"的計時器函式解析度很差，你可能需要傳入 100000，甚至 1000000，才能得到一致的結"
+"果。"
 
 #: ../../library/profile.rst:651
 msgid ""
 "When you have a consistent answer, there are three ways you can use it::"
-msgstr ""
+msgstr "當你得到一致的答案時，有三種方式可以使用它： ::"
 
 #: ../../library/profile.rst:653
 msgid ""
@@ -1083,6 +1277,17 @@ msgid ""
 "# 3. Specify computed bias in instance constructor.\n"
 "pr = profile.Profile(bias=your_computed_bias)"
 msgstr ""
+"import profile\n"
+"\n"
+"# 1. Apply computed bias to all Profile instances created hereafter.\n"
+"profile.Profile.bias = your_computed_bias\n"
+"\n"
+"# 2. Apply computed bias to a specific Profile instance.\n"
+"pr = profile.Profile()\n"
+"pr.bias = your_computed_bias\n"
+"\n"
+"# 3. Specify computed bias in instance constructor.\n"
+"pr = profile.Profile(bias=your_computed_bias)"
 
 #: ../../library/profile.rst:665
 msgid ""
@@ -1090,10 +1295,12 @@ msgid ""
 "then your results will \"less often\" show up as negative in profile "
 "statistics."
 msgstr ""
+"如果可以選擇，你最好選擇一個較小的常數，這樣你的結果在分析統計數據中「較不"
+"常」顯示為負數。"
 
 #: ../../library/profile.rst:671
 msgid "Using a custom timer"
-msgstr ""
+msgstr "使用自訂的計時器"
 
 #: ../../library/profile.rst:673
 msgid ""
@@ -1101,6 +1308,8 @@ msgid ""
 "use of wall-clock time or elapsed process time), pass the timing function "
 "you want to the :class:`Profile` class constructor::"
 msgstr ""
+"如果你想要改變目前時間的判定方式（例如，強制使用實際時鐘時間或經過的行程時"
+"間），請將你想要的計時函式傳遞給 :class:`Profile` 類別的建構函式： ::"
 
 #: ../../library/profile.rst:677
 msgid "pr = profile.Profile(your_time_func)"
@@ -1112,6 +1321,9 @@ msgid ""
 "whether you are using :class:`profile.Profile` or :class:`cProfile.Profile`, "
 "``your_time_func``'s return value will be interpreted differently:"
 msgstr ""
+"產生出的分析器接著會呼叫 ``your_time_func``。根據你使用的"
+"是 :class:`profile.Profile` 還是 :class:`cProfile.Profile`，"
+"``your_time_func`` 的回傳值會以不同的方式被解讀："
 
 #: ../../library/profile.rst:683
 msgid ":class:`profile.Profile`"
@@ -1125,6 +1337,9 @@ msgid ""
 "length 2, then you will get an especially fast version of the dispatch "
 "routine."
 msgstr ""
+"``your_time_func`` 應回傳單一數字，或一個總和為目前時間的數字串列（就"
+"像 :func:`os.times` 所回傳的那樣）。如果該函式回傳單一時間數字，或回傳的數字"
+"串列長度為 2，那麼你會得到一個特別快速版本的分派常式。"
 
 #: ../../library/profile.rst:690
 msgid ""
@@ -1137,6 +1352,11 @@ msgid ""
 "hardwire a replacement dispatch method that best handles your timer call, "
 "along with the appropriate calibration constant."
 msgstr ""
+"請注意，你應該為你所選擇的計時器函式校正分析器類別（請參閱 :ref:`profile-"
+"calibration`）。對大多數機器而言，回傳單一整數值的計時器在分析期間能以低額外"
+"負擔提供最佳結果。（:func:`os.times` 相當\\ *糟糕*，因為它回傳一個浮點數值的"
+"元組）。如果你想以最簡潔的方式替換成更好的計時器，請衍生一個類別，並寫死一個"
+"能最佳處理你的計時器呼叫的替代分派方法，以及適當的校正常數。"
 
 #: ../../library/profile.rst:699
 msgid ":class:`cProfile.Profile`"
@@ -1150,6 +1370,10 @@ msgid ""
 "``your_integer_time_func`` returns times measured in thousands of seconds, "
 "you would construct the :class:`Profile` instance as follows::"
 msgstr ""
+"``your_time_func`` 應回傳單一數字。如果它回傳整數，你也可以用第二個引數來叫用"
+"類別建構函式，以指定一個時間單位的實際持續時間。例如，如果 "
+"``your_integer_time_func`` 回傳以千分之一秒為單位測量的時間，你會像以下這樣建"
+"構 :class:`Profile` 實例： ::"
 
 #: ../../library/profile.rst:706
 msgid "pr = cProfile.Profile(your_integer_time_func, 0.001)"
@@ -1162,6 +1386,9 @@ msgid ""
 "the best results with a custom timer, it might be necessary to hard-code it "
 "in the C source of the internal :mod:`!_lsprof` module."
 msgstr ""
+"由於 :class:`cProfile.Profile` 類別無法被校正，自訂的計時器函式應謹慎使用，且"
+"應盡可能地快。要在自訂計時器下得到最佳結果，可能有必要將它寫死在內部 :mod:`!"
+"_lsprof` 模組的 C 原始碼中。"
 
 #: ../../library/profile.rst:713
 msgid ""
@@ -1169,11 +1396,13 @@ msgid ""
 "make precise measurements of process or wall-clock time. For example, see :"
 "func:`time.perf_counter`."
 msgstr ""
+"Python 3.3 在 :mod:`time` 中新增了數個新函式，可用來精確測量行程時間或實際時"
+"鐘時間。例如，請參閱 :func:`time.perf_counter`。"
 
 #: ../../library/profile.rst:16
 msgid "deterministic profiling"
-msgstr ""
+msgstr "確定性分析 (deterministic profiling)"
 
 #: ../../library/profile.rst:16
 msgid "profiling, deterministic"
-msgstr ""
+msgstr "分析，確定性 (profiling, deterministic)"


### PR DESCRIPTION
Translate the untranslated entries of `library/profile.po` (the Python Profilers documentation) into Traditional Chinese (zh_TW).