### PR TITLE
Translate `library/smtplib.po`

### DIFF
--- a/library/smtplib.po
+++ b/library/smtplib.po
@@ -32,6 +32,10 @@ msgid ""
 "daemon.  For details of SMTP and ESMTP operation, consult :rfc:`821` (Simple "
 "Mail Transfer Protocol) and :rfc:`1869` (SMTP Service Extensions)."
 msgstr ""
+":mod:`!smtplib` 模組定義了一個 SMTP 用戶端 session 物件，可用於將郵件傳送至任"
+"何具備 SMTP 或 ESMTP listener daemon 的網際網路機器。有關 SMTP 和 ESMTP 運作"
+"的細節，請參閱 :rfc:`821`\\ （Simple Mail Transfer Protocol，簡易郵件傳輸協"
+"定）和 :rfc:`1869`\\ （SMTP Service Extensions，SMTP 服務擴充）。"
 
 #: ../../includes/wasm-notavail.rst:3
 msgid "Availability"
@@ -64,12 +68,26 @@ msgid ""
 "its source address before connecting. If omitted (or if *host* or *port* are "
 "``''`` and/or ``0`` respectively) the OS default behavior will be used."
 msgstr ""
+":class:`SMTP` 實例封裝了一個 SMTP 連線。它擁有支援完整 SMTP 和 ESMTP 操作的各"
+"種方法。如果有給定選用的 *host* 和 *port* 參數，初始化期間會以這些參數呼叫 "
+"SMTP 的 :meth:`connect` 方法。如果有指定 *local_hostname*，則會將其用作 HELO/"
+"EHLO 指令中本地主機的 FQDN。否則，會使用 :func:`socket.getfqdn` 來尋找本地主"
+"機名稱。如果 :meth:`connect` 呼叫回傳的不是成功碼，則會引"
+"發 :exc:`SMTPConnectError`。選用的 *timeout* 參數會以秒為單位指定阻塞操作（例"
+"如連線嘗試）的逾時時間（如果未指定，則會使用全域預設的逾時設定）。如果逾時，"
+"則會引發 :exc:`TimeoutError`。選用的 *source_address* 參數允許在具有多個網路"
+"介面的機器中綁定到某個特定的來源位址，和/或綁定到某個特定的來源 TCP 連接埠。"
+"它接受一個 2-tuple ``(host, port)``，供 socket 在連線前綁定為其來源位址。如果"
+"省略（或者 *host* 或 *port* 分別為 ``''`` 和/或 ``0``），則會使用作業系統的預"
+"設行為。"
 
 #: ../../library/smtplib.rst:44
 msgid ""
 "For normal use, you should only require the initialization/connect, :meth:"
 "`sendmail`, and :meth:`SMTP.quit` methods. An example is included below."
 msgstr ""
+"一般使用上，你應該只會需要初始化/連線、:meth:`sendmail` 和 :meth:`SMTP.quit` "
+"等方法。以下附上一個範例。"
 
 #: ../../library/smtplib.rst:48
 msgid ""
@@ -77,6 +95,8 @@ msgid ""
 "like this, the SMTP ``QUIT`` command is issued automatically when the :"
 "keyword:`!with` statement exits.  E.g.::"
 msgstr ""
+":class:`SMTP` 類別支援 :keyword:`with` 陳述式。當這樣使用時，在 :keyword:`!"
+"with` 陳述式結束時會自動發出 SMTP ``QUIT`` 指令。例如： ::"
 
 #: ../../library/smtplib.rst:52
 msgid ""
@@ -113,13 +133,15 @@ msgstr "新增 source_address 引數。"
 
 #: ../../library/smtplib.rst:71
 msgid "The SMTPUTF8 extension (:rfc:`6531`) is now supported."
-msgstr ""
+msgstr "現在支援 SMTPUTF8 擴充（:rfc:`6531`）。"
 
 #: ../../library/smtplib.rst:74
 msgid ""
 "If the *timeout* parameter is set to be zero, it will raise a :class:"
 "`ValueError` to prevent the creation of a non-blocking socket."
 msgstr ""
+"如果 *timeout* 參數被設為零，則會引發 :class:`ValueError`，以防止建立非阻塞"
+"的 socket。"
 
 #: ../../library/smtplib.rst:81
 msgid ""
@@ -134,6 +156,13 @@ msgid ""
 "various aspects of the secure connection.  Please read :ref:`ssl-security` "
 "for best practices."
 msgstr ""
+":class:`SMTP_SSL` 實例的行為與 :class:`SMTP` 的實例完全相"
+"同。:class:`SMTP_SSL` 應該用於從連線一開始就需要 SSL、且不適合使"
+"用 :meth:`~SMTP.starttls` 的情況。如果未指定 *host*，則會使用本地主機。如果 "
+"*port* 為零，則會使用標準的 SMTP-over-SSL 連接埠（465）。選用引數 "
+"*local_hostname*、*timeout* 和 *source_address* 的意義與它們在 :class:`SMTP` "
+"類別中的相同。同樣為選用的 *context* 可以包含一個 :class:`~ssl.SSLContext`，"
+"並允許設定安全連線的各個面向。最佳做法請參閱 :ref:`ssl-security`。"
 
 #: ../../library/smtplib.rst:92 ../../library/smtplib.rst:424
 msgid "*context* was added."
@@ -148,16 +177,20 @@ msgid ""
 "The class now supports hostname check with :attr:`ssl.SSLContext."
 "check_hostname` and *Server Name Indication* (see :const:`ssl.HAS_SNI`)."
 msgstr ""
+"此類別現在支援以 :attr:`ssl.SSLContext.check_hostname` 進行主機名稱檢查以及 "
+"*Server Name Indication*\\ （請參閱 :const:`ssl.HAS_SNI`）。"
 
 #: ../../library/smtplib.rst:103
 msgid ""
 "If the *timeout* parameter is set to be zero, it will raise a :class:"
 "`ValueError` to prevent the creation of a non-blocking socket"
 msgstr ""
+"如果 *timeout* 參數被設為零，則會引發 :class:`ValueError`，以防止建立非阻塞"
+"的 socket"
 
 #: ../../library/smtplib.rst:107 ../../library/smtplib.rst:412
 msgid "The deprecated *keyfile* and *certfile* parameters have been removed."
-msgstr ""
+msgstr "已棄用的 *keyfile* 和 *certfile* 參數已被移除。"
 
 #: ../../library/smtplib.rst:113
 msgid ""
@@ -168,6 +201,11 @@ msgid ""
 "the same meaning as they do in the :class:`SMTP` class. To specify a Unix "
 "socket, you must use an absolute path for *host*, starting with a '/'."
 msgstr ""
+"LMTP 協定與 ESMTP 非常相似，它大量基於標準的 SMTP 用戶端。LMTP 常會使用 Unix "
+"socket，因此我們的 :meth:`~SMTP.connect` 方法除了支援一般的 host:port 伺服器"
+"外，也必須支援它。選用引數 *local_hostname* 和 *source_address* 的意義與它們"
+"在 :class:`SMTP` 類別中的相同。要指定一個 Unix socket，你必須為 *host* 使用"
+"以 '/' 開頭的絕對路徑。"
 
 #: ../../library/smtplib.rst:120
 msgid ""
@@ -175,6 +213,8 @@ msgid ""
 "Unix socket, LMTP generally don't support or require any authentication, but "
 "your mileage might vary."
 msgstr ""
+"支援身分驗證，使用一般的 SMTP 機制。當使用 Unix socket 時，LMTP 通常不支援或"
+"不需要任何身分驗證，但實際情況可能因人而異。"
 
 #: ../../library/smtplib.rst:124
 msgid "The optional *timeout* parameter was added."
@@ -182,17 +222,17 @@ msgstr "新增 *timeout* 選用參數。"
 
 #: ../../library/smtplib.rst:128
 msgid "A nice selection of exceptions is defined as well:"
-msgstr ""
+msgstr "此外也定義了一系列例外："
 
 #: ../../library/smtplib.rst:133
 msgid ""
 "Subclass of :exc:`OSError` that is the base exception class for all the "
 "other exceptions provided by this module."
-msgstr ""
+msgstr ":exc:`OSError` 的子類別，是此模組所提供之所有其他例外的基底例外類別。"
 
 #: ../../library/smtplib.rst:136
 msgid "SMTPException became subclass of :exc:`OSError`"
-msgstr ""
+msgstr "SMTPException 成為 :exc:`OSError` 的子類別"
 
 #: ../../library/smtplib.rst:142
 msgid ""
@@ -200,6 +240,8 @@ msgid ""
 "an attempt is made to use the :class:`SMTP` instance before connecting it to "
 "a server."
 msgstr ""
+"當伺服器非預期地中斷連線時，或者當嘗試在將 :class:`SMTP` 實例連線至伺服器之前"
+"就使用它時，會引發此例外。"
 
 #: ../../library/smtplib.rst:149
 msgid ""
@@ -207,14 +249,16 @@ msgid ""
 "exceptions are generated in some instances when the SMTP server returns an "
 "error code."
 msgstr ""
+"所有包含 SMTP 錯誤碼的例外的基底類別。當 SMTP 伺服器回傳錯誤碼時，在某些情況"
+"下會產生這些例外。"
 
 #: ../../library/smtplib.rst:154
 msgid "The error code."
-msgstr ""
+msgstr "錯誤碼。"
 
 #: ../../library/smtplib.rst:158
 msgid "The error message."
-msgstr ""
+msgstr "錯誤訊息。"
 
 #: ../../library/smtplib.rst:163
 msgid ""
@@ -222,38 +266,42 @@ msgid ""
 "`SMTPResponseException` exceptions, this sets 'sender' to the string that "
 "the SMTP server refused."
 msgstr ""
+"寄件者位址被拒絕。除了所有 :exc:`SMTPResponseException` 例外所設定的屬性外，"
+"這還會將 'sender' 設定為 SMTP 伺服器所拒絕的字串。"
 
 #: ../../library/smtplib.rst:170
 msgid "All recipient addresses refused."
-msgstr ""
+msgstr "所有收件者位址都被拒絕。"
 
 #: ../../library/smtplib.rst:174
 msgid ""
 "A dictionary of exactly the same sort as returned by :meth:`SMTP.sendmail` "
 "containing the errors for each recipient."
 msgstr ""
+"一個 dictionary，其類型與 :meth:`SMTP.sendmail` 所回傳的完全相同，包含每個收"
+"件者的錯誤。"
 
 #: ../../library/smtplib.rst:181
 msgid "The SMTP server refused to accept the message data."
-msgstr ""
+msgstr "SMTP 伺服器拒絕接受訊息資料。"
 
 #: ../../library/smtplib.rst:186
 msgid "Error occurred during establishment of a connection  with the server."
-msgstr ""
+msgstr "與伺服器建立連線的過程中發生錯誤。"
 
 #: ../../library/smtplib.rst:191
 msgid "The server refused our ``HELO`` message."
-msgstr ""
+msgstr "伺服器拒絕了我們的 ``HELO`` 訊息。"
 
 #: ../../library/smtplib.rst:196
 msgid "The command or option attempted is not supported by the server."
-msgstr ""
+msgstr "所嘗試的指令或選項不被伺服器支援。"
 
 #: ../../library/smtplib.rst:203
 msgid ""
 "SMTP authentication went wrong.  Most probably the server didn't accept the "
 "username/password combination provided."
-msgstr ""
+msgstr "SMTP 身分驗證出錯。最有可能是伺服器不接受所提供的使用者名稱/密碼組合。"
 
 #: ../../library/smtplib.rst:209
 msgid ":rfc:`821` - Simple Mail Transfer Protocol"
@@ -263,11 +311,11 @@ msgstr ":rfc:`821` - 簡易郵件傳輸協定"
 msgid ""
 "Protocol definition for SMTP.  This document covers the model, operating "
 "procedure, and protocol details for SMTP."
-msgstr ""
+msgstr "SMTP 的協定定義。本文件涵蓋了 SMTP 的模型、操作流程和協定細節。"
 
 #: ../../library/smtplib.rst:213
 msgid ":rfc:`1869` - SMTP Service Extensions"
-msgstr ""
+msgstr ":rfc:`1869` - SMTP 服務擴充"
 
 #: ../../library/smtplib.rst:214
 msgid ""
@@ -275,6 +323,8 @@ msgid ""
 "extending SMTP with new commands, supporting dynamic discovery of the "
 "commands provided by the server, and defines a few additional commands."
 msgstr ""
+"SMTP 的 ESMTP 擴充定義。這描述了一個以新指令擴充 SMTP 的框架，支援動態探查伺"
+"服器所提供的指令，並定義了一些額外的指令。"
 
 #: ../../library/smtplib.rst:222
 msgid "SMTP Objects"
@@ -291,6 +341,8 @@ msgid ""
 "the server.  A value of 2 for *level* results in these messages being "
 "timestamped."
 msgstr ""
+"設定除錯輸出的層級。*level* 為 1 或 ``True`` 會為連線以及所有傳送至伺服器和從"
+"伺服器接收的訊息產生除錯訊息。*level* 為 2 則會為這些訊息加上時間戳記。"
 
 #: ../../library/smtplib.rst:233
 msgid "Added debuglevel 2."
@@ -301,12 +353,15 @@ msgid ""
 "Send a command *cmd* to the server.  The optional argument *args* is simply "
 "concatenated to the command, separated by a space."
 msgstr ""
+"傳送一個指令 *cmd* 給伺服器。選用引數 *args* 只會以一個空格分隔串接到指令後。"
 
 #: ../../library/smtplib.rst:241
 msgid ""
 "This returns a 2-tuple composed of a numeric response code and the actual "
 "response line (multiline responses are joined into one long line.)"
 msgstr ""
+"這會回傳一個 2-tuple，由數值回應碼和實際的回應行所組成（多行回應會被合併為一"
+"長行）。"
 
 #: ../../library/smtplib.rst:244
 msgid ""
@@ -314,12 +369,15 @@ msgid ""
 "explicitly. It is used to implement other methods and may be useful for "
 "testing private extensions."
 msgstr ""
+"在正常操作中，應該不需要明確地呼叫此方法。它被用於實作其他方法，並可能對測試"
+"私有擴充很有用。"
 
 #: ../../library/smtplib.rst:248
 msgid ""
 "If the connection to the server is lost while waiting for the reply, :exc:"
 "`SMTPServerDisconnected` will be raised."
 msgstr ""
+"如果在等待回覆時與伺服器的連線中斷，則會引發 :exc:`SMTPServerDisconnected`。"
 
 #: ../../library/smtplib.rst:254
 msgid ""
@@ -331,6 +389,10 @@ msgid ""
 "Returns a 2-tuple of the response code and message sent by the server in its "
 "connection response."
 msgstr ""
+"在給定的連接埠上連線到某個主機。預設值是連線到本地主機的標準 SMTP 連接埠"
+"（25）。如果主機名稱以一個冒號（``':'``）後接一個數字結尾，該後綴會被去除，並"
+"將該數字解釋為要使用的連接埠號。如果在實例化期間有指定主機，建構函式會自動叫"
+"用此方法。回傳一個 2-tuple，內容為伺服器在其連線回應中所傳送的回應碼和訊息。"
 
 #: ../../library/smtplib.rst:262
 msgid ""
@@ -347,6 +409,9 @@ msgid ""
 "returned by the server is stored as the :attr:`helo_resp` attribute of the "
 "object."
 msgstr ""
+"使用 ``HELO`` 向 SMTP 伺服器表明你的身分。hostname 引數預設為本地主機的完整網"
+"域名稱（fully qualified domain name）。伺服器回傳的訊息會被儲存為物件"
+"的 :attr:`helo_resp` 屬性。"
 
 #: ../../library/smtplib.rst:272
 msgid ""
@@ -354,6 +419,8 @@ msgid ""
 "explicitly. It will be implicitly called by the :meth:`sendmail` when "
 "necessary."
 msgstr ""
+"在正常操作中，應該不需要明確地呼叫此方法。必要時它會被 :meth:`sendmail` 隱式"
+"地呼叫。"
 
 #: ../../library/smtplib.rst:278
 msgid ""
@@ -366,6 +433,12 @@ msgid ""
 "attr:`esmtp_features` will be a dictionary containing the names of the SMTP "
 "service extensions this server supports, and their parameters (if any)."
 msgstr ""
+"使用 ``EHLO`` 向 ESMTP 伺服器表明你的身分。hostname 引數預設為本地主機的完整"
+"網域名稱（fully qualified domain name）。檢視回應中的 ESMTP 選項並將其儲存起"
+"來，供 :meth:`has_extn` 使用。同時也會設定數個資訊性屬性：伺服器回傳的訊息會"
+"被儲存為 :attr:`ehlo_resp` 屬性，:attr:`does_esmtp` 會依伺服器是否支援 ESMTP "
+"被設為 ``True`` 或 ``False``，而 :attr:`esmtp_features` 會是一個 dictionary，"
+"包含此伺服器所支援的 SMTP 服務擴充名稱以及它們的參數（如果有的話）。"
 
 #: ../../library/smtplib.rst:288
 msgid ""
@@ -373,6 +446,8 @@ msgid ""
 "be necessary to call this method explicitly.  It will be implicitly called "
 "by :meth:`sendmail` when necessary."
 msgstr ""
+"除非你想在寄送郵件前使用 :meth:`has_extn`，否則應該不需要明確地呼叫此方法。必"
+"要時它會被 :meth:`sendmail` 隱式地呼叫。"
 
 #: ../../library/smtplib.rst:294
 msgid ""
@@ -380,6 +455,8 @@ msgid ""
 "previous ``EHLO`` or ``HELO`` command this session.  It tries ESMTP ``EHLO`` "
 "first."
 msgstr ""
+"如果此 session 之前沒有過 ``EHLO`` 或 ``HELO`` 指令，此方法會呼"
+"叫 :meth:`ehlo` 和/或 :meth:`helo`。它會先嘗試 ESMTP 的 ``EHLO``。"
 
 #: ../../library/smtplib.rst:298 ../../library/smtplib.rst:327
 #: ../../library/smtplib.rst:415 ../../library/smtplib.rst:483
@@ -389,13 +466,15 @@ msgstr ":exc:`SMTPHeloError`"
 #: ../../library/smtplib.rst:299 ../../library/smtplib.rst:328
 #: ../../library/smtplib.rst:416 ../../library/smtplib.rst:484
 msgid "The server didn't reply properly to the ``HELO`` greeting."
-msgstr ""
+msgstr "伺服器沒有正確地回覆 ``HELO`` 問候。"
 
 #: ../../library/smtplib.rst:303
 msgid ""
 "Return :const:`True` if *name* is in the set of SMTP service extensions "
 "returned by the server, :const:`False` otherwise. Case is ignored."
 msgstr ""
+"如果 *name* 在伺服器回傳的 SMTP 服務擴充集合中，則回傳 :const:`True`，否則回"
+"傳 :const:`False`。大小寫會被忽略。"
 
 #: ../../library/smtplib.rst:309
 msgid ""
@@ -404,10 +483,13 @@ msgid ""
 "human name) if the user address is valid. Otherwise returns an SMTP error "
 "code of 400 or greater and an error string."
 msgstr ""
+"使用 SMTP 的 ``VRFY`` 檢查某個位址在此伺服器上的有效性。如果使用者位址有效，"
+"則回傳一個由碼 250 和一個完整的 :rfc:`822` 位址（包含人類可讀的名稱）組成的 "
+"tuple。否則回傳一個 400 或更大的 SMTP 錯誤碼以及一個錯誤字串。"
 
 #: ../../library/smtplib.rst:316
 msgid "Many sites disable SMTP ``VRFY`` in order to foil spammers."
-msgstr ""
+msgstr "許多站台會停用 SMTP 的 ``VRFY`` 以阻擋垃圾郵件發送者。"
 
 #: ../../library/smtplib.rst:321
 msgid ""
@@ -417,6 +499,9 @@ msgid ""
 "``EHLO`` first. This method will return normally if the authentication was "
 "successful, or may raise the following exceptions:"
 msgstr ""
+"登入一個需要身分驗證的 SMTP 伺服器。引數為用來驗證的使用者名稱和密碼。如果此 "
+"session 之前沒有過 ``EHLO`` 或 ``HELO`` 指令，此方法會先嘗試 ESMTP 的 "
+"``EHLO``。如果身分驗證成功，此方法會正常回傳，否則可能引發以下例外："
 
 #: ../../library/smtplib.rst:330
 msgid ":exc:`SMTPAuthenticationError`"
@@ -424,7 +509,7 @@ msgstr ":exc:`SMTPAuthenticationError`"
 
 #: ../../library/smtplib.rst:331
 msgid "The server didn't accept the username/password combination."
-msgstr ""
+msgstr "伺服器不接受該使用者名稱/密碼組合。"
 
 #: ../../library/smtplib.rst:333 ../../library/smtplib.rst:418
 #: ../../library/smtplib.rst:493
@@ -433,7 +518,7 @@ msgstr ":exc:`SMTPNotSupportedError`"
 
 #: ../../library/smtplib.rst:334
 msgid "The ``AUTH`` command is not supported by the server."
-msgstr ""
+msgstr "伺服器不支援 ``AUTH`` 指令。"
 
 #: ../../library/smtplib.rst:336
 msgid ":exc:`SMTPException`"
@@ -441,7 +526,7 @@ msgstr ":exc:`SMTPException`"
 
 #: ../../library/smtplib.rst:337
 msgid "No suitable authentication method was found."
-msgstr ""
+msgstr "找不到合適的身分驗證方法。"
 
 #: ../../library/smtplib.rst:339
 msgid ""
@@ -450,6 +535,9 @@ msgid ""
 "for a list of supported authentication methods.  *initial_response_ok* is "
 "passed through to :meth:`auth`."
 msgstr ""
+"如果伺服器宣告支援 :mod:`!smtplib` 所支援的每一種身分驗證方法，這些方法會被依"
+"序嘗試。支援的身分驗證方法清單請參閱 :meth:`auth`。*initial_response_ok* 會被"
+"傳遞給 :meth:`auth`。"
 
 #: ../../library/smtplib.rst:344
 msgid ""
@@ -458,18 +546,25 @@ msgid ""
 "in :rfc:`4954` can be sent along with the ``AUTH`` command, rather than "
 "requiring a challenge/response."
 msgstr ""
+"選用的關鍵字引數 *initial_response_ok* 指定對於支援它的身分驗證方法，是否可以"
+"將 :rfc:`4954` 中所指定的「initial response（初始回應）」隨 ``AUTH`` 指令一起"
+"傳送，而非要求一次 challenge/response。"
 
 #: ../../library/smtplib.rst:349
 msgid ""
 ":exc:`SMTPNotSupportedError` may be raised, and the *initial_response_ok* "
 "parameter was added."
 msgstr ""
+"可能會引發 :exc:`SMTPNotSupportedError`，並新增了 *initial_response_ok* 參"
+"數。"
 
 #: ../../library/smtplib.rst:356
 msgid ""
 "Issue an ``SMTP`` ``AUTH`` command for the specified authentication "
 "*mechanism*, and handle the challenge response via *authobject*."
 msgstr ""
+"為指定的身分驗證 *mechanism* 發出一個 ``SMTP`` ``AUTH`` 指令，並透過 "
+"*authobject* 處理 challenge 回應。"
 
 #: ../../library/smtplib.rst:359
 msgid ""
@@ -477,11 +572,13 @@ msgid ""
 "argument to the ``AUTH`` command; the valid values are those listed in the "
 "``auth`` element of :attr:`esmtp_features`."
 msgstr ""
+"*mechanism* 指定要用作 ``AUTH`` 指令引數的身分驗證機制；有效值"
+"為 :attr:`esmtp_features` 的 ``auth`` 元素中所列出的那些。"
 
 #: ../../library/smtplib.rst:363
 msgid ""
 "*authobject* must be a callable object taking an optional single argument::"
-msgstr ""
+msgstr "*authobject* 必須是一個接受單一選用引數的可呼叫物件： ::"
 
 #: ../../library/smtplib.rst:365
 msgid "data = authobject(challenge=None)"
@@ -497,6 +594,12 @@ msgid ""
 "``None`` when called with ``challenge=None``.  If *initial_response_ok* is "
 "false, then ``authobject()`` will not be called first with ``None``."
 msgstr ""
+"如果選用的關鍵字引數 *initial_response_ok* 為真，``authobject()`` 會先在不帶"
+"引數的情況下被呼叫。它可以回傳 :rfc:`4954` 的「initial response（初始回應）」"
+"ASCII ``str``，該回應會如下被編碼並隨 ``AUTH`` 指令一起傳送。如果 "
+"``authobject()`` 不支援初始回應（例如因為它需要一個 challenge），則它在以 "
+"``challenge=None`` 被呼叫時應回傳 ``None``。如果 *initial_response_ok* 為假，"
+"則 ``authobject()`` 不會先以 ``None`` 被呼叫。"
 
 #: ../../library/smtplib.rst:375
 msgid ""
@@ -506,6 +609,10 @@ msgid ""
 "should return ASCII ``str`` *data* that will be base64 encoded and sent to "
 "the server."
 msgstr ""
+"如果初始回應檢查回傳 ``None``，或者如果 *initial_response_ok* 為假，"
+"``authobject()`` 會被呼叫以處理伺服器的 challenge 回應；傳遞給它的 "
+"*challenge* 引數會是一個 ``bytes``。它應回傳會被 base64 編碼並傳送至伺服器的 "
+"ASCII ``str`` *data*。"
 
 #: ../../library/smtplib.rst:381
 msgid ""
@@ -515,6 +622,10 @@ msgid ""
 "the ``user`` and ``password`` properties of the ``SMTP`` instance are set to "
 "appropriate values."
 msgstr ""
+"``SMTP`` 類別為 ``CRAM-MD5``、``PLAIN`` 和 ``LOGIN`` 機制提供了 "
+"``authobjects``；它們分別被命名為 ``SMTP.auth_cram_md5``、"
+"``SMTP.auth_plain`` 和 ``SMTP.auth_login``。它們都要求 ``SMTP`` 實例的 "
+"``user`` 和 ``password`` 屬性被設定為適當的值。"
 
 #: ../../library/smtplib.rst:387
 msgid ""
@@ -524,6 +635,9 @@ msgid ""
 "implementation of authentication methods not (or not yet) supported directly "
 "by :mod:`!smtplib`."
 msgstr ""
+"使用者程式碼通常不需要直接呼叫 ``auth``，而是可以改為呼叫 :meth:`login` 方"
+"法，它會依所列順序依序嘗試上述每一種機制。``auth`` 被公開出來是為了方便實"
+"作 :mod:`!smtplib` 尚未（或還沒有）直接支援的身分驗證方法。"
 
 #: ../../library/smtplib.rst:398
 msgid ""
@@ -531,12 +645,16 @@ msgid ""
 "commands that follow will be encrypted.  You should then call :meth:`ehlo` "
 "again."
 msgstr ""
+"將 SMTP 連線置於 TLS（Transport Layer Security，傳輸層安全性）模式。後續所有"
+"的 SMTP 指令都會被加密。接著你應該再次呼叫 :meth:`ehlo`。"
 
 #: ../../library/smtplib.rst:402
 msgid ""
 "If *keyfile* and *certfile* are provided, they are used to create an :class:"
 "`ssl.SSLContext`."
 msgstr ""
+"如果有提供 *keyfile* 和 *certfile*，它們會被用來建立一"
+"個 :class:`ssl.SSLContext`。"
 
 #: ../../library/smtplib.rst:405
 msgid ""
@@ -544,16 +662,21 @@ msgid ""
 "an alternative to using a keyfile and a certfile and if specified both "
 "*keyfile* and *certfile* should be ``None``."
 msgstr ""
+"選用的 *context* 參數是一個 :class:`ssl.SSLContext` 物件；這是使用 keyfile "
+"和 certfile 的替代方案，如果有指定它，則 *keyfile* 和 *certfile* 都應為 "
+"``None``。"
 
 #: ../../library/smtplib.rst:409
 msgid ""
 "If there has been no previous ``EHLO`` or ``HELO`` command this session, "
 "this method tries ESMTP ``EHLO`` first."
 msgstr ""
+"如果此 session 之前沒有過 ``EHLO`` 或 ``HELO`` 指令，此方法會先嘗試 ESMTP 的 "
+"``EHLO``。"
 
 #: ../../library/smtplib.rst:419
 msgid "The server does not support the STARTTLS extension."
-msgstr ""
+msgstr "伺服器不支援 STARTTLS 擴充。"
 
 #: ../../library/smtplib.rst:421
 msgid ":exc:`RuntimeError`"
@@ -561,19 +684,23 @@ msgstr ":exc:`RuntimeError`"
 
 #: ../../library/smtplib.rst:422
 msgid "SSL/TLS support is not available to your Python interpreter."
-msgstr ""
+msgstr "你的 Python 直譯器無法使用 SSL/TLS 支援。"
 
 #: ../../library/smtplib.rst:427
 msgid ""
 "The method now supports hostname check with :attr:`ssl.SSLContext."
 "check_hostname` and *Server Name Indicator* (see :const:`~ssl.HAS_SNI`)."
 msgstr ""
+"此方法現在支援以 :attr:`ssl.SSLContext.check_hostname` 進行主機名稱檢查以及 "
+"*Server Name Indicator*\\ （請參閱 :const:`~ssl.HAS_SNI`）。"
 
 #: ../../library/smtplib.rst:432
 msgid ""
 "The error raised for lack of STARTTLS support is now the :exc:"
 "`SMTPNotSupportedError` subclass instead of the base :exc:`SMTPException`."
 msgstr ""
+"針對缺乏 STARTTLS 支援所引發的錯誤現在是 :exc:`SMTPNotSupportedError` 子類"
+"別，而非基底的 :exc:`SMTPException`。"
 
 #: ../../library/smtplib.rst:440
 msgid ""
@@ -589,6 +716,14 @@ msgid ""
 "recipients you have to use the low-level methods such as :meth:`!mail`, :"
 "meth:`!rcpt` and :meth:`!data` to send the message.)"
 msgstr ""
+"寄送郵件。必要引數為一個 :rfc:`822` 寄件位址字串、一個 :rfc:`822` 收件位址字"
+"串的 list（單一字串會被視為含有 1 個位址的 list），以及一個訊息字串。呼叫者可"
+"以傳入一個 ESMTP 選項的 list（例如 ``\"8bitmime\"``）作為 *mail_options*，供 "
+"``MAIL FROM`` 指令使用。應與所有 ``RCPT`` 指令一起使用的 ESMTP 選項（例如 "
+"``DSN`` 指令）可以作為 *rcpt_options* 傳入。每個選項都應作為一個包含該選項完"
+"整文字的字串傳入，包括任何可能的鍵（例如 ``\"NOTIFY=SUCCESS,FAILURE\"``）。"
+"（如果你需要對不同的收件者使用不同的 ESMTP 選項，你必須使用如 :meth:`!"
+"mail`、:meth:`!rcpt` 和 :meth:`!data` 等低階方法來寄送訊息。）"
 
 #: ../../library/smtplib.rst:453
 msgid ""
@@ -596,6 +731,8 @@ msgid ""
 "envelope used by the transport agents.  ``sendmail`` does not modify the "
 "message headers in any way."
 msgstr ""
+"*from_addr* 和 *to_addrs* 參數用來建構傳輸代理（transport agent）所使用的訊息"
+"信封（message envelope）。``sendmail`` 不會以任何方式修改訊息標頭。"
 
 #: ../../library/smtplib.rst:457
 msgid ""
@@ -604,6 +741,9 @@ msgid ""
 "``\\r`` and ``\\n`` characters are converted to ``\\r\\n`` characters.  A "
 "byte string is not modified."
 msgstr ""
+"*msg* 可以是一個包含 ASCII 範圍內字元的字串，或者一個位元組字串。字串會使用 "
+"ascii codec 被編碼為位元組，而單獨的 ``\\r`` 和 ``\\n`` 字元會被轉換為 "
+"``\\r\\n`` 字元。位元組字串不會被修改。"
 
 #: ../../library/smtplib.rst:462
 msgid ""
@@ -613,6 +753,10 @@ msgid ""
 "is in the feature set the server advertises).  If ``EHLO`` fails, ``HELO`` "
 "will be tried and ESMTP options suppressed."
 msgstr ""
+"如果此 session 之前沒有過 ``EHLO`` 或 ``HELO`` 指令，此方法會先嘗試 ESMTP 的 "
+"``EHLO``。如果伺服器支援 ESMTP，訊息大小和每個指定的選項都會被傳遞給它（如果"
+"該選項在伺服器宣告的功能集合中）。如果 ``EHLO`` 失敗，則會嘗試 ``HELO`` 並抑"
+"制 ESMTP 選項。"
 
 #: ../../library/smtplib.rst:468
 msgid ""
@@ -623,16 +767,22 @@ msgid ""
 "for each recipient that was refused.  Each entry contains a tuple of the "
 "SMTP error code and the accompanying error message sent by the server."
 msgstr ""
+"如果郵件至少被一個收件者接受，此方法會正常回傳。否則它會引發一個例外。也就是"
+"說，如果此方法沒有引發例外，那麼應該會有人收到你的郵件。如果此方法沒有引發例"
+"外，它會回傳一個 dictionary，其中每個被拒絕的收件者都有一個條目。每個條目都包"
+"含一個由 SMTP 錯誤碼和伺服器所傳送的隨附錯誤訊息組成的 tuple。"
 
 #: ../../library/smtplib.rst:475
 msgid ""
 "If ``SMTPUTF8`` is included in *mail_options*, and the server supports it, "
 "*from_addr* and *to_addrs* may contain non-ASCII characters."
 msgstr ""
+"如果 ``SMTPUTF8`` 被包含在 *mail_options* 中且伺服器支援它，則 *from_addr* "
+"和 *to_addrs* 可以包含非 ASCII 字元。"
 
 #: ../../library/smtplib.rst:478
 msgid "This method may raise the following exceptions:"
-msgstr ""
+msgstr "此方法可能引發以下例外："
 
 #: ../../library/smtplib.rst:480
 msgid ":exc:`SMTPRecipientsRefused`"
@@ -640,7 +790,7 @@ msgstr ":exc:`SMTPRecipientsRefused`"
 
 #: ../../library/smtplib.rst:481
 msgid "All recipients were refused.  Nobody got the mail."
-msgstr ""
+msgstr "所有收件者都被拒絕。沒有人收到郵件。"
 
 #: ../../library/smtplib.rst:486
 msgid ":exc:`SMTPSenderRefused`"
@@ -648,7 +798,7 @@ msgstr ":exc:`SMTPSenderRefused`"
 
 #: ../../library/smtplib.rst:487
 msgid "The server didn't accept the *from_addr*."
-msgstr ""
+msgstr "伺服器不接受 *from_addr*。"
 
 #: ../../library/smtplib.rst:489
 msgid ":exc:`SMTPDataError`"
@@ -658,29 +808,31 @@ msgstr ":exc:`SMTPDataError`"
 msgid ""
 "The server replied with an unexpected error code (other than a refusal of a "
 "recipient)."
-msgstr ""
+msgstr "伺服器以一個非預期的錯誤碼回覆（而非拒絕某個收件者）。"
 
 #: ../../library/smtplib.rst:494
 msgid ""
 "``SMTPUTF8`` was given in the *mail_options* but is not supported by the "
 "server."
-msgstr ""
+msgstr "*mail_options* 中有給定 ``SMTPUTF8``，但伺服器不支援它。"
 
 #: ../../library/smtplib.rst:497
 msgid ""
 "Unless otherwise noted, the connection will be open even after an exception "
 "is raised."
-msgstr ""
+msgstr "除非另有說明，否則即使在引發例外後，連線仍會保持開啟。"
 
 #: ../../library/smtplib.rst:500
 msgid "*msg* may be a byte string."
-msgstr ""
+msgstr "*msg* 可以是一個位元組字串。"
 
 #: ../../library/smtplib.rst:503
 msgid ""
 "``SMTPUTF8`` support added, and :exc:`SMTPNotSupportedError` may be raised "
 "if ``SMTPUTF8`` is specified but the server does not support it."
 msgstr ""
+"新增 ``SMTPUTF8`` 支援，且如果指定了 ``SMTPUTF8`` 但伺服器不支援它，可能會引"
+"發 :exc:`SMTPNotSupportedError`。"
 
 #: ../../library/smtplib.rst:511
 msgid ""
@@ -689,6 +841,9 @@ msgid ""
 "the same meaning as for :meth:`sendmail`, except that *msg* is a ``Message`` "
 "object."
 msgstr ""
+"這是一個便利方法，用於以一個 :class:`email.message.Message` 物件所表示的訊息"
+"呼叫 :meth:`sendmail`。引數的意義與 :meth:`sendmail` 的相同，但 *msg* 是一個 "
+"``Message`` 物件。"
 
 #: ../../library/smtplib.rst:516
 msgid ""
@@ -704,6 +859,15 @@ msgid ""
 "`ValueError` is raised, since there is no way to unambiguously detect the "
 "most recent set of :mailheader:`Resent-` headers."
 msgstr ""
+"如果 *from_addr* 為 ``None`` 或 *to_addrs* 為 ``None``，``send_message`` 會"
+"依 :rfc:`5322` 中所指定的方式，以從 *msg* 的標頭中擷取出的位址填入這些引數："
+"如果 :mailheader:`Sender` 欄位存在，*from_addr* 會被設為該欄位，否則設"
+"為 :mailheader:`From` 欄位。*to_addrs* 會結合 *msg* "
+"中 :mailheader:`To`、:mailheader:`Cc` 和 :mailheader:`Bcc` 欄位的值（如果有的"
+"話）。如果訊息中剛好出現一組 :mailheader:`Resent-*` 標頭，則一般的標頭會被忽"
+"略，並改用 :mailheader:`Resent-*` 標頭。如果訊息包含超過一"
+"組 :mailheader:`Resent-*` 標頭，則會引發 :exc:`ValueError`，因為無法明確地偵"
+"測出最近的那組 :mailheader:`Resent-` 標頭。"
 
 #: ../../library/smtplib.rst:528
 msgid ""
@@ -719,16 +883,25 @@ msgid ""
 "EmailPolicy.utf8` attribute set to ``True``, and ``SMTPUTF8`` and "
 "``BODY=8BITMIME`` are added to *mail_options*."
 msgstr ""
+"``send_message`` 會使用 :class:`~email.generator.BytesGenerator` 並以 "
+"``\\r\\n`` 作為 *linesep* 來序列化 *msg*，並呼叫 :meth:`sendmail` 來傳輸產生"
+"的訊息。無論 *from_addr* 和 *to_addrs* 的值為何，``send_message`` 都不會傳輸 "
+"*msg* 中可能出現的任何 :mailheader:`Bcc` 或 :mailheader:`Resent-Bcc` 標頭。如"
+"果 *from_addr* 和 *to_addrs* 中有任何位址包含非 ASCII 字元，且伺服器未宣告支"
+"援 ``SMTPUTF8``，則會引發 :exc:`SMTPNotSupportedError`。否則 ``Message`` 會以"
+"其 :mod:`~email.policy` 的副本（其中 :attr:`~email.policy.EmailPolicy.utf8` "
+"屬性被設為 ``True``）進行序列化，且 ``SMTPUTF8`` 和 ``BODY=8BITMIME`` 會被新"
+"增到 *mail_options*。"
 
 #: ../../library/smtplib.rst:542
 msgid "Support for internationalized addresses (``SMTPUTF8``)."
-msgstr ""
+msgstr "對國際化位址（``SMTPUTF8``）的支援。"
 
 #: ../../library/smtplib.rst:548
 msgid ""
 "Terminate the SMTP session and close the connection.  Return the result of "
 "the SMTP ``QUIT`` command."
-msgstr ""
+msgstr "終止 SMTP session 並關閉連線。回傳 SMTP ``QUIT`` 指令的結果。"
 
 #: ../../library/smtplib.rst:552
 msgid ""
@@ -737,6 +910,9 @@ msgid ""
 "supported. Normally these do not need to be called directly, so they are not "
 "documented here.  For details, consult the module code."
 msgstr ""
+"也支援對應於標準 SMTP/ESMTP 指令 ``HELP``、``RSET``、``NOOP``、``MAIL``、"
+"``RCPT`` 和 ``DATA`` 的低階方法。通常這些方法不需要被直接呼叫，因此這裡不對它"
+"們加以說明。詳情請參閱模組程式碼。"
 
 #: ../../library/smtplib.rst:557
 msgid "Additionally, an SMTP instance has the following attributes:"
@@ -744,23 +920,24 @@ msgstr "此外，SMTP 實例擁有以下屬性："
 
 #: ../../library/smtplib.rst:562
 msgid "The response to the ``HELO`` command, see :meth:`helo`."
-msgstr ""
+msgstr "對 ``HELO`` 指令的回應，請參閱 :meth:`helo`。"
 
 #: ../../library/smtplib.rst:567
 msgid "The response to the ``EHLO`` command, see :meth:`ehlo`."
-msgstr ""
+msgstr "對 ``EHLO`` 指令的回應，請參閱 :meth:`ehlo`。"
 
 #: ../../library/smtplib.rst:572
 msgid ""
 "A boolean value indicating whether the server supports ESMTP, see :meth:"
 "`ehlo`."
-msgstr ""
+msgstr "一個 boolean 值，指出伺服器是否支援 ESMTP，請參閱 :meth:`ehlo`。"
 
 #: ../../library/smtplib.rst:578
 msgid ""
 "A dictionary of the names of SMTP service extensions supported by the "
 "server, see :meth:`ehlo`."
 msgstr ""
+"一個包含伺服器所支援之 SMTP 服務擴充名稱的 dictionary，請參閱 :meth:`ehlo`。"
 
 #: ../../library/smtplib.rst:585
 msgid "SMTP Example"
@@ -775,6 +952,10 @@ msgid ""
 "In particular, the 'To' and 'From' addresses must be included in the message "
 "headers explicitly::"
 msgstr ""
+"這個範例會提示使用者輸入訊息信封中所需的位址（「To」和「From」位址），以及要"
+"傳遞的訊息。請注意，要隨訊息一起包含的標頭必須在輸入訊息時就包含進去；這個範"
+"例不會對 :rfc:`822` 標頭做任何處理。特別是，「To」和「From」位址必須明確地包"
+"含在訊息標頭中： ::"
 
 #: ../../library/smtplib.rst:593
 msgid ""
@@ -805,6 +986,32 @@ msgid ""
 "server.sendmail(from_addr, to_addrs, msg)\n"
 "server.quit()"
 msgstr ""
+"import smtplib\n"
+"\n"
+"def prompt(title):\n"
+"    return input(title).strip()\n"
+"\n"
+"from_addr = prompt(\"From: \")\n"
+"to_addrs  = prompt(\"To: \").split()\n"
+"print(\"Enter message, end with ^D (Unix) or ^Z (Windows):\")\n"
+"\n"
+"# Add the From: and To: headers at the start!\n"
+"lines = [f\"From: {from_addr}\", f\"To: {', '.join(to_addrs)}\", \"\"]\n"
+"while True:\n"
+"    try:\n"
+"        line = input()\n"
+"    except EOFError:\n"
+"        break\n"
+"    else:\n"
+"        lines.append(line)\n"
+"\n"
+"msg = \"\\r\\n\".join(lines)\n"
+"print(\"Message length is\", len(msg))\n"
+"\n"
+"server = smtplib.SMTP(\"localhost\")\n"
+"server.set_debuglevel(1)\n"
+"server.sendmail(from_addr, to_addrs, msg)\n"
+"server.quit()"
 
 #: ../../library/smtplib.rst:622
 msgid ""
@@ -812,6 +1019,9 @@ msgid ""
 "construct an email message, which you can then send via :meth:`~smtplib.SMTP."
 "send_message`; see :ref:`email-examples`."
 msgstr ""
+"一般而言，你會想使用 :mod:`email` 套件的功能來建構電子郵件訊息，接著就可以透"
+"過 :meth:`~smtplib.SMTP.send_message` 來寄送它；請參閱 :ref:`email-"
+"examples`。"
 
 #: ../../library/smtplib.rst:11
 msgid "SMTP"

--- a/library/smtplib.po
+++ b/library/smtplib.po
@@ -178,7 +178,7 @@ msgid ""
 "check_hostname` and *Server Name Indication* (see :const:`ssl.HAS_SNI`)."
 msgstr ""
 "此類別現在支援以 :attr:`ssl.SSLContext.check_hostname` 進行主機名稱檢查以及 "
-"*Server Name Indication*\\ （請參閱 :const:`ssl.HAS_SNI`）。"
+"*伺服器名稱指示 (Server Name Indication)*\\ （請參閱 :const:`ssl.HAS_SNI`）。"
 
 #: ../../library/smtplib.rst:103
 msgid ""
@@ -213,7 +213,7 @@ msgid ""
 "Unix socket, LMTP generally don't support or require any authentication, but "
 "your mileage might vary."
 msgstr ""
-"支援身分驗證，使用一般的 SMTP 機制。當使用 Unix socket 時，LMTP 通常不支援或"
+"支援使用一般的 SMTP 機制進行身分驗證。當使用 Unix socket 時，LMTP 通常不支援或"
 "不需要任何身分驗證，但實際情況可能因人而異。"
 
 #: ../../library/smtplib.rst:124
@@ -240,7 +240,7 @@ msgid ""
 "an attempt is made to use the :class:`SMTP` instance before connecting it to "
 "a server."
 msgstr ""
-"當伺服器非預期地中斷連線時，或者當嘗試在將 :class:`SMTP` 實例連線至伺服器之前"
+"當伺服器意外斷線時，或者當嘗試在將 :class:`SMTP` 實例連線至伺服器之前"
 "就使用它時，會引發此例外。"
 
 #: ../../library/smtplib.rst:149
@@ -484,12 +484,12 @@ msgid ""
 "code of 400 or greater and an error string."
 msgstr ""
 "使用 SMTP 的 ``VRFY`` 檢查某個位址在此伺服器上的有效性。如果使用者位址有效，"
-"則回傳一個由碼 250 和一個完整的 :rfc:`822` 位址（包含人類可讀的名稱）組成的 "
+"則回傳一個由代號 250 和一個完整的 :rfc:`822` 位址（包含人名）組成的 "
 "tuple。否則回傳一個 400 或更大的 SMTP 錯誤碼以及一個錯誤字串。"
 
 #: ../../library/smtplib.rst:316
 msgid "Many sites disable SMTP ``VRFY`` in order to foil spammers."
-msgstr "許多站台會停用 SMTP 的 ``VRFY`` 以阻擋垃圾郵件發送者。"
+msgstr "許多網站會停用 SMTP 的 ``VRFY`` 以阻擋垃圾郵件發送者。"
 
 #: ../../library/smtplib.rst:321
 msgid ""
@@ -548,7 +548,7 @@ msgid ""
 msgstr ""
 "選用的關鍵字引數 *initial_response_ok* 指定對於支援它的身分驗證方法，是否可以"
 "將 :rfc:`4954` 中所指定的「initial response（初始回應）」隨 ``AUTH`` 指令一起"
-"傳送，而非要求一次 challenge/response。"
+"傳送，而非要求進行 challenge（質詢）/response（回應）。"
 
 #: ../../library/smtplib.rst:349
 msgid ""
@@ -995,7 +995,7 @@ msgstr ""
 "to_addrs  = prompt(\"To: \").split()\n"
 "print(\"Enter message, end with ^D (Unix) or ^Z (Windows):\")\n"
 "\n"
-"# Add the From: and To: headers at the start!\n"
+"# 在開頭加上 From: 和 To: 標頭！\n"
 "lines = [f\"From: {from_addr}\", f\"To: {', '.join(to_addrs)}\", \"\"]\n"
 "while True:\n"
 "    try:\n"


### PR DESCRIPTION
Translate the untranslated entries of `library/smtplib.po` (SMTP protocol client) into Traditional Chinese (zh_TW).