### PR TITLE
Translate `library/asyncio-runner.po`

### DIFF
--- a/library/asyncio-runner.po
+++ b/library/asyncio-runner.po
@@ -55,8 +55,8 @@ msgid ""
 "This function runs the awaitable, taking care of managing the asyncio event "
 "loop, *finalizing asynchronous generators*, and closing the executor."
 msgstr ""
-"這個函式負責運行被傳入的可等待物件、管理 asyncio 的事件迴圈、*終結非同步產生器*\\ 以"
-"及關閉執行器。"
+"這個函式負責運行被傳入的可等待物件、管理 asyncio 的事件迴圈、*終結非同步產生"
+"器*\\ 以及關閉執行器。"
 
 #: ../../library/asyncio-runner.rst:35 ../../library/asyncio-runner.rst:131
 msgid ""
@@ -96,6 +96,8 @@ msgid ""
 "executor hasn't finished within that duration, a warning is emitted and the "
 "executor is closed."
 msgstr ""
+"執行器的關閉逾時期限為 5 分鐘。如果執行器未在這段時間內完成，系統會發出警告並"
+"關閉執行器。"
 
 #: ../../library/asyncio-runner.rst:54
 msgid "Example::"
@@ -117,12 +119,12 @@ msgstr ""
 
 #: ../../library/asyncio-runner.rst:64
 msgid "Updated to use :meth:`loop.shutdown_default_executor`."
-msgstr ""
+msgstr "更新為使用\\ :meth:`loop.shutdown_default_executor`。"
 
 #: ../../library/asyncio-runner.rst:69
 msgid ""
 "*debug* is ``None`` by default to respect the global debug mode settings."
-msgstr ""
+msgstr "*debug* 預設為 ``None``，以遵循全域除錯模式設定。"
 
 #: ../../library/asyncio-runner.rst:73
 msgid "Added *loop_factory* parameter."
@@ -130,7 +132,7 @@ msgstr "新增 *loop_factory* 參數。"
 
 #: ../../library/asyncio-runner.rst:77 ../../library/asyncio-runner.rst:136
 msgid "*coro* can be any awaitable object."
-msgstr ""
+msgstr "*coro* 可以是任何可等待物件。"
 
 #: ../../library/asyncio-runner.rst:81
 msgid ""
@@ -138,22 +140,26 @@ msgid ""
 "Python 3.16; from there on, an explicit *loop_factory* is needed to "
 "configure the event loop."
 msgstr ""
+":mod:`!asyncio` 的政策系統已被棄用，並將於 Python 3.16 移除；此後必須明確指"
+"定 *loop_factory* 才能設定事件迴圈。"
 
 #: ../../library/asyncio-runner.rst:87
 msgid "Runner context manager"
-msgstr ""
+msgstr "執行器情境管理器"
 
 #: ../../library/asyncio-runner.rst:91
 msgid ""
 "A context manager that simplifies *multiple* async function calls in the "
 "same context."
-msgstr ""
+msgstr "此情境管理器可簡化在相同情境中對\\ *多個*\\ 非同步函式的呼叫。"
 
 #: ../../library/asyncio-runner.rst:94
 msgid ""
 "Sometimes several top-level async functions should be called in the "
 "same :ref:`event loop <asyncio-event-loop>` and :class:`contextvars.Context`."
 msgstr ""
+"有時需要在相同的\\ :ref:`事件迴圈 <asyncio-event-loop>` "
+"和 :class:`contextvars.Context` 中呼叫數個頂層非同步函式。"
 
 #: ../../library/asyncio-runner.rst:101
 msgid ""
@@ -162,12 +168,16 @@ msgid ""
 "one. By default :func:`asyncio.new_event_loop` is used and set as current "
 "event loop with :func:`asyncio.set_event_loop` if *loop_factory* is ``None``."
 msgstr ""
+"*loop_factory* 可用來覆寫事件迴圈的建立方式。*loop_factory* 必須負責將建立的"
+"迴圈設定為目前的事件迴圈。若 *loop_factory* 為 ``None``，預設會使用"
+"\\ :func:`asyncio.new_event_loop`，並以\\ :func:`asyncio.set_event_loop` 將其"
+"設定為目前的事件迴圈。"
 
 #: ../../library/asyncio-runner.rst:106
 msgid ""
 "Basically, :func:`asyncio.run` example can be rewritten with the runner "
 "usage::"
-msgstr ""
+msgstr "基本上，:func:`asyncio.run`\\ 的範例可以改寫為使用執行器： ::"
 
 #: ../../library/asyncio-runner.rst:108
 msgid ""
@@ -187,11 +197,11 @@ msgstr ""
 
 #: ../../library/asyncio-runner.rst:119
 msgid "Execute *coro* in the embedded event loop."
-msgstr ""
+msgstr "在內嵌的事件迴圈中執行 *coro*。"
 
 #: ../../library/asyncio-runner.rst:123
 msgid "If the argument is a coroutine, it is wrapped in a Task."
-msgstr ""
+msgstr "如果引數是協程，會將其包裝在 Task 中。"
 
 #: ../../library/asyncio-runner.rst:125
 msgid ""
@@ -199,40 +209,48 @@ msgid ""
 "custom :class:`contextvars.Context` for the code to run in. The runner's "
 "default context is used if context is ``None``."
 msgstr ""
+"可選的僅限關鍵字引數 *context*，可用來指定程式碼執行時所使用的自訂"
+"\\ :class:`contextvars.Context`。如果 context 為 ``None``，則使用執行器的預設"
+"情境。"
 
 #: ../../library/asyncio-runner.rst:129
 msgid "Returns the awaitable's result or raises an exception."
-msgstr ""
+msgstr "回傳可等待物件的結果，或引發例外。"
 
 #: ../../library/asyncio-runner.rst:140
 msgid "Close the runner."
-msgstr ""
+msgstr "關閉執行器。"
 
 #: ../../library/asyncio-runner.rst:142
 msgid ""
 "Finalize asynchronous generators, shutdown default executor, close the event "
 "loop and release embedded :class:`contextvars.Context`."
 msgstr ""
+"最終化非同步產生器、關閉預設執行器與事件迴圈，並釋放內嵌的"
+"\\ :class:`contextvars.Context`。"
 
 #: ../../library/asyncio-runner.rst:147
 msgid "Return the event loop associated with the runner instance."
-msgstr ""
+msgstr "回傳與執行器實例關聯的事件迴圈。"
 
 #: ../../library/asyncio-runner.rst:151
 msgid ""
 ":class:`Runner` uses the lazy initialization strategy, its constructor "
 "doesn't initialize underlying low-level structures."
 msgstr ""
+":class:`Runner` 採用延遲初始化策略，其建構函式不會初始化底層的低階結構。"
 
 #: ../../library/asyncio-runner.rst:154
 msgid ""
 "Embedded *loop* and *context* are created at the :keyword:`with` body "
 "entering or the first call of :meth:`run` or :meth:`get_loop`."
 msgstr ""
+"內嵌的 *loop* 和 *context* 會在進入\\ :keyword:`with`\\ 陳述式主體，或第一次"
+"呼叫\\ :meth:`run`\\ 或\\ :meth:`get_loop`\\ 時建立。"
 
 #: ../../library/asyncio-runner.rst:159
 msgid "Handling Keyboard Interruption"
-msgstr ""
+msgstr "處理鍵盤中斷"
 
 #: ../../library/asyncio-runner.rst:163
 msgid ""
@@ -241,12 +259,16 @@ msgid ""
 "default. However this doesn't work with :mod:`asyncio` because it can "
 "interrupt asyncio internals and can hang the program from exiting."
 msgstr ""
+"當 :const:`signal.SIGINT` 由 :kbd:`Ctrl-C` 引發時，預設會在主執行緒中引"
+"發 :exc:`KeyboardInterrupt` 例外。然而，此方式不適用於 :mod:`asyncio`，因為這"
+"可能會中斷 asyncio 內部運作，並造成程式無法結束。"
 
 #: ../../library/asyncio-runner.rst:168
 msgid ""
 "To mitigate this issue, :mod:`asyncio` handles :const:`signal.SIGINT` as "
 "follows:"
 msgstr ""
+"為了緩解此問題，:mod:`asyncio` 會依下列方式處理 :const:`signal.SIGINT`："
 
 #: ../../library/asyncio-runner.rst:170
 msgid ""
@@ -254,12 +276,14 @@ msgid ""
 "before any user code is executed and removes it when exiting from the "
 "function."
 msgstr ""
+":meth:`asyncio.Runner.run` 會在執行任何使用者程式碼之前安裝自訂"
+"的 :const:`signal.SIGINT` 處理程式，並在函式結束時將其移除。"
 
 #: ../../library/asyncio-runner.rst:172
 msgid ""
 "The :class:`~asyncio.Runner` creates the main task for the passed coroutine "
 "for its execution."
-msgstr ""
+msgstr ":class:`~asyncio.Runner` 會為傳入的協程建立主 Task，以執行該協程。"
 
 #: ../../library/asyncio-runner.rst:174
 msgid ""
@@ -270,6 +294,11 @@ msgid ""
 "used for resource cleanup.  After the main task is "
 "cancelled, :meth:`asyncio.Runner.run` raises :exc:`KeyboardInterrupt`."
 msgstr ""
+"當 :const:`signal.SIGINT` 由 :kbd:`Ctrl-C` 引發時，自訂訊號處理程式會呼"
+"叫 :meth:`asyncio.Task.cancel` 來取消主 Task，而此方法會在主 Task 內引"
+"發 :exc:`asyncio.CancelledError`。這會使 Python 堆疊展開，並可使用 ``try/"
+"except`` 與 ``try/finally`` 區塊來清理資源。主 Task 取消"
+"後，:meth:`asyncio.Runner.run` 會引發 :exc:`KeyboardInterrupt`。"
 
 #: ../../library/asyncio-runner.rst:180
 msgid ""
@@ -278,3 +307,6 @@ msgid ""
 "following :kbd:`Ctrl-C` immediately raises the :exc:`KeyboardInterrupt` "
 "without cancelling the main task."
 msgstr ""
+"使用者可能會撰寫一個無法由 :meth:`asyncio.Task.cancel` 中斷的緊密迴圈；在此情"
+"況下，再次按下 :kbd:`Ctrl-C` 會立即引發 :exc:`KeyboardInterrupt`，而不會取消"
+"主 Task。"

--- a/library/asyncio-runner.po
+++ b/library/asyncio-runner.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: ../../library/asyncio-runner.rst:6
 msgid "Runners"
-msgstr "Runners (執行器)"
+msgstr "Runner"
 
 #: ../../library/asyncio-runner.rst:8
 msgid "**Source code:** :source:`Lib/asyncio/runners.py`"
@@ -40,7 +40,7 @@ msgstr ""
 
 #: ../../library/asyncio-runner.rst:23
 msgid "Running an asyncio Program"
-msgstr "運行一個 asyncio 程式"
+msgstr "執行 asyncio 程式"
 
 #: ../../library/asyncio-runner.rst:27
 msgid "Execute *coro* in an asyncio event loop and return the result."
@@ -55,7 +55,7 @@ msgid ""
 "This function runs the awaitable, taking care of managing the asyncio event "
 "loop, *finalizing asynchronous generators*, and closing the executor."
 msgstr ""
-"這個函式負責運行被傳入的可等待物件、管理 asyncio 的事件迴圈、*終結非同步產生"
+"這個函式負責執行傳入的可等待物件、管理 asyncio 的事件迴圈、*最終化非同步產生"
 "器*\\ 以及關閉執行器。"
 
 #: ../../library/asyncio-runner.rst:35 ../../library/asyncio-runner.rst:131
@@ -119,12 +119,12 @@ msgstr ""
 
 #: ../../library/asyncio-runner.rst:64
 msgid "Updated to use :meth:`loop.shutdown_default_executor`."
-msgstr "更新為使用\\ :meth:`loop.shutdown_default_executor`。"
+msgstr "更新為使用 :meth:`loop.shutdown_default_executor`。"
 
 #: ../../library/asyncio-runner.rst:69
 msgid ""
 "*debug* is ``None`` by default to respect the global debug mode settings."
-msgstr "*debug* 預設為 ``None``，以遵循全域除錯模式設定。"
+msgstr "*debug* 預設為 ``None``，以遵循全域偵錯模式設定。"
 
 #: ../../library/asyncio-runner.rst:73
 msgid "Added *loop_factory* parameter."
@@ -145,7 +145,7 @@ msgstr ""
 
 #: ../../library/asyncio-runner.rst:87
 msgid "Runner context manager"
-msgstr "執行器情境管理器"
+msgstr "Runner 情境管理器"
 
 #: ../../library/asyncio-runner.rst:91
 msgid ""
@@ -158,7 +158,7 @@ msgid ""
 "Sometimes several top-level async functions should be called in the "
 "same :ref:`event loop <asyncio-event-loop>` and :class:`contextvars.Context`."
 msgstr ""
-"有時需要在相同的\\ :ref:`事件迴圈 <asyncio-event-loop>` "
+"有時需要在相同的 :ref:`事件迴圈 <asyncio-event-loop>` "
 "和 :class:`contextvars.Context` 中呼叫數個頂層非同步函式。"
 
 #: ../../library/asyncio-runner.rst:101
@@ -169,15 +169,15 @@ msgid ""
 "event loop with :func:`asyncio.set_event_loop` if *loop_factory* is ``None``."
 msgstr ""
 "*loop_factory* 可用來覆寫事件迴圈的建立方式。*loop_factory* 必須負責將建立的"
-"迴圈設定為目前的事件迴圈。若 *loop_factory* 為 ``None``，預設會使用"
-"\\ :func:`asyncio.new_event_loop`，並以\\ :func:`asyncio.set_event_loop` 將其"
-"設定為目前的事件迴圈。"
+"迴圈設定為目前的事件迴圈。若 *loop_factory* 為 ``None``，預設會使"
+"用 :func:`asyncio.new_event_loop`，並以 :func:`asyncio.set_event_loop` 將其設"
+"定為目前的事件迴圈。"
 
 #: ../../library/asyncio-runner.rst:106
 msgid ""
 "Basically, :func:`asyncio.run` example can be rewritten with the runner "
 "usage::"
-msgstr "基本上，:func:`asyncio.run`\\ 的範例可以改寫為使用執行器： ::"
+msgstr "基本上，:func:`asyncio.run` 的範例可以改寫為使用 Runner： ::"
 
 #: ../../library/asyncio-runner.rst:108
 msgid ""
@@ -209,9 +209,9 @@ msgid ""
 "custom :class:`contextvars.Context` for the code to run in. The runner's "
 "default context is used if context is ``None``."
 msgstr ""
-"可選的僅限關鍵字引數 *context*，可用來指定程式碼執行時所使用的自訂"
-"\\ :class:`contextvars.Context`。如果 context 為 ``None``，則使用執行器的預設"
-"情境。"
+"可選的僅限關鍵字引數 *context*，可用來指定程式碼執行時所使用的自"
+"訂 :class:`contextvars.Context`。如果 context 為 ``None``，則使用 Runner 的預"
+"設情境。"
 
 #: ../../library/asyncio-runner.rst:129
 msgid "Returns the awaitable's result or raises an exception."
@@ -219,19 +219,19 @@ msgstr "回傳可等待物件的結果，或引發例外。"
 
 #: ../../library/asyncio-runner.rst:140
 msgid "Close the runner."
-msgstr "關閉執行器。"
+msgstr "關閉 Runner。"
 
 #: ../../library/asyncio-runner.rst:142
 msgid ""
 "Finalize asynchronous generators, shutdown default executor, close the event "
 "loop and release embedded :class:`contextvars.Context`."
 msgstr ""
-"最終化非同步產生器、關閉預設執行器與事件迴圈，並釋放內嵌的"
-"\\ :class:`contextvars.Context`。"
+"最終化非同步產生器、關閉預設執行器與事件迴圈，並釋放內嵌"
+"的 :class:`contextvars.Context`。"
 
 #: ../../library/asyncio-runner.rst:147
 msgid "Return the event loop associated with the runner instance."
-msgstr "回傳與執行器實例關聯的事件迴圈。"
+msgstr "回傳與 Runner 實例關聯的事件迴圈。"
 
 #: ../../library/asyncio-runner.rst:151
 msgid ""
@@ -245,8 +245,8 @@ msgid ""
 "Embedded *loop* and *context* are created at the :keyword:`with` body "
 "entering or the first call of :meth:`run` or :meth:`get_loop`."
 msgstr ""
-"內嵌的 *loop* 和 *context* 會在進入\\ :keyword:`with`\\ 陳述式主體，或第一次"
-"呼叫\\ :meth:`run`\\ 或\\ :meth:`get_loop`\\ 時建立。"
+"內嵌的 *loop* 和 *context* 會在進入 :keyword:`with` 陳述式主體，或第一次呼"
+"叫 :meth:`run` 或 :meth:`get_loop` 時建立。"
 
 #: ../../library/asyncio-runner.rst:159
 msgid "Handling Keyboard Interruption"


### PR DESCRIPTION
完成 `library/asyncio-runner.po` 的 26 筆未翻譯字串。

- `runner` 依 issue 建議譯為「執行器」
- `event loop` 依目前 3.14 asyncio 翻譯用語譯為「事件迴圈」
- 保留 reST roles、link targets、inline literals 與程式識別字

驗證：

- `make build library/asyncio-runner.po`
- `uvx powrap --check library/asyncio-runner.po`
- `msgfmt --check --statistics -o /dev/null library/asyncio-runner.po`（41 translated）
- `sphinx-lint --enable default-role library/asyncio-runner.po`（No problems found）

全庫 `make lint` 仍會列出其他既有檔案的 default-role 問題；本次目標檔案沒有 lint 問題。

Closes #683